### PR TITLE
Miscellaneous fixes and improvements

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,6 +16,10 @@ on:
       - 'LICENSE'
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build and Test

--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@ A drop-in alternative to SwiftUI's `AsyncImage`, with support for custom URLSess
 
 ![build](https://github.com/bdbergeron/remoteimage/actions/workflows/build-and-test.yml/badge.svg)
 [![codecov](https://codecov.io/gh/bdbergeron/remoteimage/graph/badge.svg?token=1PYkoRXex8)](https://codecov.io/gh/bdbergeron/remoteimage)
+
+## Getting Started
+
+Add RemoteImage to your project via Swift Package Manager:
+
+```swift
+.package(url: "https://github.com/bdbergeron/RemoteImage", from: "1.0.0"),
+```

--- a/Sources/RemoteImage/RemoteImage.swift
+++ b/Sources/RemoteImage/RemoteImage.swift
@@ -1,5 +1,6 @@
 // Created by Brad Bergeron on 8/31/23.
 
+import OSLog
 import SwiftUI
 
 // MARK: - RemoteImageConfiguration
@@ -15,17 +16,22 @@ public struct RemoteImageConfiguration {
   ///   - scale: The scale to use for the image. The default is `1`. Set a different value when loading images designed for higher resolution displays.
   ///     For example, set a value of `2` for an image that you would name with the `@2x` suffix if stored in a file on disk.
   ///   - transaction: The transaction to use when the phase changes. Default is an empty `Transaction`.
-  ///   - disableTransactionWithCachedResponse: Whether or not to disable the ``transaction`` when a cached image is returned. Defaults to `true`.
+  ///   - disableTransactionWithCachedResponse: Whether or not to disable the ``transaction`` when a cached image is returned.
+  ///     Defaults to `true`.
+  ///   - logger: An optional `Logger` instance that will be used internally. Defaults to one that utilizes the "io.github.bdbergeron.RemoteImage" subsystem
+  ///     and "RemoteImage" category.
   public init(
     skipCache: Bool = false,
     scale: CGFloat = 1.0,
     transaction: Transaction = .init(),
-    disableTransactionWithCachedResponse: Bool = true)
+    disableTransactionWithCachedResponse: Bool = true,
+    logger: Logger? = .init(subsystem: "io.github.bdbergeron.RemoteImage", category: "RemoteImage"))
   {
     self.skipCache = skipCache
     self.scale = scale
     self.transaction = transaction
     self.disableTransactionWithCachedResponse = disableTransactionWithCachedResponse
+    self.logger = logger
   }
 
   // MARK: Internal
@@ -34,6 +40,7 @@ public struct RemoteImageConfiguration {
   let scale: CGFloat
   let transaction: Transaction
   let disableTransactionWithCachedResponse: Bool
+  let logger: Logger?
 
 }
 
@@ -85,10 +92,7 @@ public struct RemoteImage<Content: View>: View {
       wrappedValue: RemoteImageViewModel(
         url: url,
         urlSession: urlSession,
-        skipCache: configuration.skipCache,
-        scale: configuration.scale,
-        transaction: configuration.transaction,
-        disableTransactionWithCachedResponse: configuration.disableTransactionWithCachedResponse))
+        configuration: configuration))
     self.content = content
   }
 
@@ -221,10 +225,7 @@ extension RemoteImage {
       wrappedValue: RemoteImageViewModel(
         url: url,
         cache: cache,
-        skipCache: configuration.skipCache,
-        scale: configuration.scale,
-        transaction: configuration.transaction,
-        disableTransactionWithCachedResponse: configuration.disableTransactionWithCachedResponse))
+        configuration: configuration))
     self.content = content
   }
 

--- a/Sources/RemoteImage/RemoteImageViewModel.swift
+++ b/Sources/RemoteImage/RemoteImageViewModel.swift
@@ -88,15 +88,14 @@ final class RemoteImageViewModel: ObservableObject {
 
   /// When the view owning this model appears, load the image from either the local cache or remote URL.
   func onAppear() {
+    if case .loaded = phase {
+      return
+    }
     if
       !skipCache,
       let cachedImage
     {
       setPhase(.loaded(cachedImage), animated: false)
-      return
-    }
-    if case .loaded(let image) = phase {
-      setPhase(.loaded(image), animated: false)
       return
     }
     loadingTask = Task {

--- a/Tests/RemoteImageTests/RemoteImageViewModelTests.swift
+++ b/Tests/RemoteImageTests/RemoteImageViewModelTests.swift
@@ -59,17 +59,23 @@ final class RemoteImageViewModelTests: XCTestCase {
   }
 
   func test_loadImage_skipsLoadIfPhaseIsAlreadyLoaded() async throws {
-    try await urlSession.fetchImage(from: .cuteDoggoPicture)
     let model = RemoteImageViewModel(url: .cuteDoggoPicture, urlSession: urlSession)
+    guard case .placeholder = model.phase else {
+      XCTFail("Initial phase should be `.placeholder`.")
+      return
+    }
+
+    try await urlSession.fetchImage(from: .cuteDoggoPicture)
+
     model.onAppear()
+    XCTAssertNil(model.loadingTask)
     guard case .loaded = model.phase else {
-      XCTFail("Initial phase should be `.loaded`.")
+      XCTFail("Phase should be `.loaded`.")
       return
     }
     
     model.onAppear()
     XCTAssertNil(model.loadingTask)
-
     guard case .loaded = model.phase else {
       XCTFail("Phase should still be `.loaded`.")
       return

--- a/Tests/RemoteImageTests/RemoteImageViewModelTests.swift
+++ b/Tests/RemoteImageTests/RemoteImageViewModelTests.swift
@@ -1,5 +1,6 @@
 // Created by Brad Bergeron on 8/31/23.
 
+import OSLog
 import Stubby
 import SwiftUI
 import XCTest
@@ -28,7 +29,11 @@ final class RemoteImageViewModelTests: XCTestCase {
   }
 
   func test_cachedImage_returnsNilIfSkipCache() {
-    let model = RemoteImageViewModel(url: nil, urlSession: urlSession, skipCache: true)
+    let model = RemoteImageViewModel(
+      url: nil, 
+      urlSession: urlSession,
+      configuration: .init(
+        skipCache: true))
     XCTAssertNil(model.cachedImage)
   }
 


### PR DESCRIPTION
- Fixes #2.
- Clean up the internal model initializers to take a `RemoteImageConfiguration` object directly, removing the individual parameters. We now have a single source-of-truth for the default configuration parameters.
- Allow overriding the internal `Logger` via the `RemoteImageConfiguration`.
- Make `loadImageIfNeeded()` private and update test to call `onAppear()` and `onDisappear()`, correctly mimicking what the `RemoteImage` view does.