### PR TITLE
Create demo app, add new initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,96 @@
 # 🖼️ RemoteImage
 A drop-in alternative to SwiftUI's `AsyncImage`, with support for custom URLSessions, caching, and animated phase changes.
 
-![build](https://github.com/bdbergeron/remoteimage/actions/workflows/build-and-test.yml/badge.svg)
+![build-ios](https://github.com/bdbergeron/remoteimage/actions/workflows/build-and-test-ios.yml/badge.svg)
+![build-macos](https://github.com/bdbergeron/remoteimage/actions/workflows/build-and-test-macos.yml/badge.svg)
 [![codecov](https://codecov.io/gh/bdbergeron/remoteimage/graph/badge.svg?token=1PYkoRXex8)](https://codecov.io/gh/bdbergeron/remoteimage)
 
 ## Getting Started
 
-Add RemoteImage to your project via Swift Package Manager:
+Add `RemoteImage` to your project via Swift Package Manager, and add `import RemoteImage` where you want to use it.
 
 ```swift
 .package(url: "https://github.com/bdbergeron/RemoteImage", from: "1.0.0"),
+```
+
+## Usage
+
+`RemoteImage`'s APIs have been designed to make it super easy to adopt in your app/project. In most cases, it's a simple drop-in replacement for SwiftUI's `AsyncImage`.
+
+### Simple Configuration
+
+```swift
+let imageURL: URL?
+
+/// A simple `RemoteImage` view.
+#Preview("Simple") {
+  RemoteImage(url: imageULRL)
+}
+
+/// A simple `RemoteImage` view, with modifier.
+#Preview("Simple, with image modifier") {
+  RemoteImage(url: imageURL) {
+    $0.resizable().scaledToFit()
+  }
+}
+
+/// A `RemoteImage` view with a custom placeholder.
+#Preview("Custom placeholder") {
+  RemoteImage(url: imageURL) { image in
+    image.resizable().scaledToFit()
+  } placeholder: {
+    ProgressView()
+  }
+}
+
+/// A `RemoteImage` view with custom content.
+#Preview("Custom content") {
+  RemoteImage(url: imageURL) { phase in
+    switch phase {
+    case .placeholder:
+      ProgressView()
+    case .loaded(let image):
+      image.resizable().scaledToFit()
+    case .failure:
+      ZStack {
+        Color.yellow.opacity(0.3)
+        Text("Image could not be loaded.")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+    }
+  }
+}
+```
+
+### Advanced Configuration
+
+```swift
+let imageURL: URL?
+let urlSession: URLSession
+let imageCache: URLCache
+
+/// Image loaded with a custom `URLSession`, skipping the cache, and using a custom
+/// phase transition animation.
+#Preview("Custom URLSession") {
+  RemoteImage(
+    url: .cuteDoggo,
+    urlSession: .shared,
+    configuration: RemoteImageConfiguration(
+      skipCache: true,
+      transaction: Transaction(
+        animation: .easeInOut(duration: 0.5))))
+  {
+    $0.resizable().scaledToFit()
+  }
+}
+
+/// Image loaded from a custom cache. If the image is not yet cached, a new `URLSession`
+/// will be constructed using the `URLSessionConfiguration.default` configuration
+/// and the provided cache instance.
+#Preview("Custom URLCache") {
+  RemoteImage(url: .cuteDoggo, cache: .shared) { image in
+    image.resizable().scaledToFit()
+  }
+}
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Add `RemoteImage` to your project via Swift Package Manager, and add `import Rem
 
 `RemoteImage`'s APIs have been designed to make it super easy to adopt in your app/project. In most cases, it's a simple drop-in replacement for SwiftUI's `AsyncImage`.
 
+Check out the `RemoteImage Demos` app in the Xcode project to see some live exmaples.
+
+![Demos](.github/readme/RemoteImageDemos.gif)
+
 ### Simple Configuration
 
 ```swift
@@ -24,10 +28,10 @@ let imageURL: URL?
 
 /// A simple `RemoteImage` view.
 #Preview("Simple") {
-  RemoteImage(url: imageULRL)
+  RemoteImage(url: imageURL)
 }
 
-/// A simple `RemoteImage` view, with modifier.
+/// A simple `RemoteImage` view with modifier closure.
 #Preview("Simple, with image modifier") {
   RemoteImage(url: imageURL) {
     $0.resizable().scaledToFit()
@@ -36,8 +40,8 @@ let imageURL: URL?
 
 /// A `RemoteImage` view with a custom placeholder.
 #Preview("Custom placeholder") {
-  RemoteImage(url: imageURL) { image in
-    image.resizable().scaledToFit()
+  RemoteImage(url: imageURL) {
+    $0.resizable().scaledToFit()
   } placeholder: {
     ProgressView()
   }
@@ -67,19 +71,17 @@ let imageURL: URL?
 
 ```swift
 let imageURL: URL?
-let urlSession: URLSession
-let imageCache: URLCache
+let urlSession = URLSession(configuration: .ephemeral)
+let imageCache = URLCache(memoryCapacity: 10_000_000, diskCapacity: 0)
 
-/// Image loaded with a custom `URLSession`, skipping the cache, and using a custom
-/// phase transition animation.
+/// Image loaded with a custom `URLSession` and using a custom phase transition animation.
 #Preview("Custom URLSession") {
   RemoteImage(
-    url: .cuteDoggo,
-    urlSession: .shared,
+    url: imageURL,
+    urlSession: urlSession,
     configuration: RemoteImageConfiguration(
-      skipCache: true,
       transaction: Transaction(
-        animation: .easeInOut(duration: 0.5))))
+        animation: .spring(duration: 1.0).delay(0.5))))
   {
     $0.resizable().scaledToFit()
   }
@@ -89,8 +91,8 @@ let imageCache: URLCache
 /// will be constructed using the `URLSessionConfiguration.default` configuration
 /// and the provided cache instance.
 #Preview("Custom URLCache") {
-  RemoteImage(url: .cuteDoggo, cache: .shared) { image in
-    image.resizable().scaledToFit()
+  RemoteImage(url: imageURL, cache: imageCache) {
+    $0.resizable().scaledToFit()
   }
 }
 ```

--- a/RemoteImage.xcodeproj/project.pbxproj
+++ b/RemoteImage.xcodeproj/project.pbxproj
@@ -129,13 +129,6 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
-		5C0D6A092AB7A1490017092C /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		5C6968452AAE4EE300F8BA44 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
@@ -214,7 +207,6 @@
 				OBJ_13 /* Products */,
 				OBJ_16 /* LICENSE */,
 				OBJ_18 /* README.md */,
-				5C0D6A092AB7A1490017092C /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};

--- a/RemoteImage.xcodeproj/project.pbxproj
+++ b/RemoteImage.xcodeproj/project.pbxproj
@@ -19,6 +19,12 @@
 		5C8E909C2ABF771E00181B57 /* RemoteImage+InitWithCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8E909B2ABF771E00181B57 /* RemoteImage+InitWithCache.swift */; };
 		5C8E909E2ABF775000181B57 /* RemoteImageViewModel+InitWithCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8E909D2ABF775000181B57 /* RemoteImageViewModel+InitWithCache.swift */; };
 		5C8E90A02ABF78E300181B57 /* RemoteImage+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8E909F2ABF78E300181B57 /* RemoteImage+Helpers.swift */; };
+		5C8E90A82ABF7F1D00181B57 /* RemoteImageDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8E90A72ABF7F1D00181B57 /* RemoteImageDemoApp.swift */; };
+		5C8E90AA2ABF7F1D00181B57 /* DemosList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8E90A92ABF7F1D00181B57 /* DemosList.swift */; };
+		5C8E90AC2ABF7F1E00181B57 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5C8E90AB2ABF7F1E00181B57 /* Assets.xcassets */; };
+		5C8E90AF2ABF7F1E00181B57 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5C8E90AE2ABF7F1E00181B57 /* Preview Assets.xcassets */; };
+		5C8E90B52ABF800E00181B57 /* RemoteImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "remoteimage::RemoteImage::Product" /* RemoteImage.framework */; };
+		5C8E90B62ABF800E00181B57 /* RemoteImage.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = "remoteimage::RemoteImage::Product" /* RemoteImage.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5CE5B0062AB38B4A000F79A8 /* Doggo.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 5CA9A4C92AB265CD00A00232 /* Doggo.jpg */; };
 		5CF539AA2ABA666A001E98ED /* RemoteImageStubbedURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF539A92ABA666A001E98ED /* RemoteImageStubbedURL.swift */; };
 		OBJ_24 /* RemoteImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* RemoteImage.swift */; };
@@ -34,7 +40,28 @@
 			remoteGlobalIDString = "remoteimage::RemoteImage";
 			remoteInfo = RemoteImage;
 		};
+		5C8E90B72ABF800E00181B57 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "remoteimage::RemoteImage";
+			remoteInfo = RemoteImage;
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		5C8E90B92ABF800E00181B57 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				5C8E90B62ABF800E00181B57 /* RemoteImage.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		5C08C6142ABE22410020D48B /* Image+PlatformNativeImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Image+PlatformNativeImage.swift"; sourceTree = "<group>"; };
@@ -46,6 +73,11 @@
 		5C8E909B2ABF771E00181B57 /* RemoteImage+InitWithCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteImage+InitWithCache.swift"; sourceTree = "<group>"; };
 		5C8E909D2ABF775000181B57 /* RemoteImageViewModel+InitWithCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteImageViewModel+InitWithCache.swift"; sourceTree = "<group>"; };
 		5C8E909F2ABF78E300181B57 /* RemoteImage+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteImage+Helpers.swift"; sourceTree = "<group>"; };
+		5C8E90A52ABF7F1D00181B57 /* RemoteImageDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RemoteImageDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		5C8E90A72ABF7F1D00181B57 /* RemoteImageDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImageDemoApp.swift; sourceTree = "<group>"; };
+		5C8E90A92ABF7F1D00181B57 /* DemosList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemosList.swift; sourceTree = "<group>"; };
+		5C8E90AB2ABF7F1E00181B57 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		5C8E90AE2ABF7F1E00181B57 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		5CA9A4C92AB265CD00A00232 /* Doggo.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = Doggo.jpg; sourceTree = "<group>"; };
 		5CF539A92ABA666A001E98ED /* RemoteImageStubbedURL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteImageStubbedURL.swift; sourceTree = "<group>"; };
 		5CF5C4FE2AA258FC00B3FC01 /* RemoteImage.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteImage.xctestplan; sourceTree = "<group>"; };
@@ -59,6 +91,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		5C8E90A22ABF7F1D00181B57 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5C8E90B52ABF800E00181B57 /* RemoteImage.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		OBJ_25 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
@@ -105,6 +145,25 @@
 			path = Helpers;
 			sourceTree = "<group>";
 		};
+		5C8E90A62ABF7F1D00181B57 /* RemoteImageDemo */ = {
+			isa = PBXGroup;
+			children = (
+				5C8E90A72ABF7F1D00181B57 /* RemoteImageDemoApp.swift */,
+				5C8E90A92ABF7F1D00181B57 /* DemosList.swift */,
+				5C8E90AB2ABF7F1E00181B57 /* Assets.xcassets */,
+				5C8E90AD2ABF7F1E00181B57 /* Preview Content */,
+			);
+			path = RemoteImageDemo;
+			sourceTree = "<group>";
+		};
+		5C8E90AD2ABF7F1E00181B57 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				5C8E90AE2ABF7F1E00181B57 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
 		5CA9A4C82AB265CD00A00232 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -139,6 +198,7 @@
 			children = (
 				"remoteimage::RemoteImage::Product" /* RemoteImage.framework */,
 				"remoteimage::RemoteImageTests::Product" /* RemoteImageTests.xctest */,
+				5C8E90A52ABF7F1D00181B57 /* RemoteImageDemo.app */,
 			);
 			name = Products;
 			sourceTree = BUILT_PRODUCTS_DIR;
@@ -150,6 +210,7 @@
 				OBJ_6 /* Package.swift */,
 				OBJ_7 /* Sources */,
 				OBJ_10 /* Tests */,
+				5C8E90A62ABF7F1D00181B57 /* RemoteImageDemo */,
 				OBJ_13 /* Products */,
 				OBJ_16 /* LICENSE */,
 				OBJ_18 /* README.md */,
@@ -182,6 +243,25 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		5C8E90A42ABF7F1D00181B57 /* RemoteImageDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5C8E90B32ABF7F1E00181B57 /* Build configuration list for PBXNativeTarget "RemoteImageDemo" */;
+			buildPhases = (
+				5C8E90A12ABF7F1D00181B57 /* Sources */,
+				5C8E90A22ABF7F1D00181B57 /* Frameworks */,
+				5C8E90A32ABF7F1D00181B57 /* Resources */,
+				5C8E90B92ABF800E00181B57 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5C8E90B82ABF800E00181B57 /* PBXTargetDependency */,
+			);
+			name = RemoteImageDemo;
+			productName = RemoteImageDemo;
+			productReference = 5C8E90A52ABF7F1D00181B57 /* RemoteImageDemo.app */;
+			productType = "com.apple.product-type.application";
+		};
 		"remoteimage::RemoteImage" /* RemoteImage */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = OBJ_20 /* Build configuration list for PBXNativeTarget "RemoteImage" */;
@@ -231,7 +311,13 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftMigration = 9999;
+				LastSwiftUpdateCheck = 1500;
 				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					5C8E90A42ABF7F1D00181B57 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+				};
 			};
 			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "RemoteImage" */;
 			compatibilityVersion = "Xcode 13.0";
@@ -252,6 +338,7 @@
 			targets = (
 				"remoteimage::RemoteImage" /* RemoteImage */,
 				"remoteimage::RemoteImageTests" /* RemoteImageTests */,
+				5C8E90A42ABF7F1D00181B57 /* RemoteImageDemo */,
 			);
 		};
 /* End PBXProject section */
@@ -265,9 +352,27 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		5C8E90A32ABF7F1D00181B57 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5C8E90AF2ABF7F1E00181B57 /* Preview Assets.xcassets in Resources */,
+				5C8E90AC2ABF7F1E00181B57 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		5C8E90A12ABF7F1D00181B57 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5C8E90AA2ABF7F1D00181B57 /* DemosList.swift in Sources */,
+				5C8E90A82ABF7F1D00181B57 /* RemoteImageDemoApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		OBJ_23 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
@@ -297,6 +402,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		5C8E90B82ABF800E00181B57 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "remoteimage::RemoteImage" /* RemoteImage */;
+			targetProxy = 5C8E90B72ABF800E00181B57 /* PBXContainerItemProxy */;
+		};
 		OBJ_45 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "remoteimage::RemoteImage" /* RemoteImage */;
@@ -340,8 +450,8 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
-					"SWIFT_PACKAGE=1",
 					"DEBUG=1",
+					"TESTING=1",
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
@@ -357,7 +467,7 @@
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = "$(AVAILABLE_PLATFORMS)";
 				SUPPORTS_MACCATALYST = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE TEST";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) TEST";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				USE_HEADERMAP = NO;
 			};
@@ -373,6 +483,10 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SWIFT_PACKAGE=1",
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = RemoteImage.xcodeproj/RemoteImage_Info.plist;
@@ -390,7 +504,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				TARGET_NAME = RemoteImage;
@@ -411,6 +525,10 @@
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SWIFT_PACKAGE=1",
+				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = RemoteImage.xcodeproj/RemoteImageTests_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -424,7 +542,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				TARGET_NAME = RemoteImageTests;
@@ -432,6 +550,169 @@
 				WATCHOS_DEPLOYMENT_TARGET = 7.0;
 			};
 			name = Testing;
+		};
+		5C8E90B02ABF7F1E00181B57 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"RemoteImageDemo/Preview Content\"";
+				DEVELOPMENT_TEAM = 5WUK689P3B;
+				ENABLE_PREVIEWS = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bradbergeron.RemoteImageDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		5C8E90B12ABF7F1E00181B57 /* Testing */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"RemoteImageDemo/Preview Content\"";
+				DEVELOPMENT_TEAM = 5WUK689P3B;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_PREVIEWS = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bradbergeron.RemoteImageDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Testing;
+		};
+		5C8E90B22ABF7F1E00181B57 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"RemoteImageDemo/Preview Content\"";
+				DEVELOPMENT_TEAM = 5WUK689P3B;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_PREVIEWS = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bradbergeron.RemoteImageDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
 		};
 		OBJ_21 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -443,6 +724,10 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SWIFT_PACKAGE=1",
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = RemoteImage.xcodeproj/RemoteImage_Info.plist;
@@ -460,7 +745,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				TARGET_NAME = RemoteImage;
@@ -480,6 +765,10 @@
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SWIFT_PACKAGE=1",
+				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = RemoteImage.xcodeproj/RemoteImage_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -496,7 +785,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				TARGET_NAME = RemoteImage;
@@ -541,7 +830,6 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
-					"SWIFT_PACKAGE=1",
 					"DEBUG=1",
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -558,7 +846,7 @@
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = "$(AVAILABLE_PLATFORMS)";
 				SUPPORTS_MACCATALYST = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE DEBUG";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				USE_HEADERMAP = NO;
 			};
@@ -576,6 +864,10 @@
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SWIFT_PACKAGE=1",
+				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = RemoteImage.xcodeproj/RemoteImageTests_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -589,7 +881,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				TARGET_NAME = RemoteImageTests;
@@ -630,10 +922,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = s;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"SWIFT_PACKAGE=1",
-				);
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -647,7 +936,7 @@
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = "$(AVAILABLE_PLATFORMS)";
 				SUPPORTS_MACCATALYST = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				USE_HEADERMAP = NO;
@@ -666,6 +955,10 @@
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SWIFT_PACKAGE=1",
+				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = RemoteImage.xcodeproj/RemoteImageTests_Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -679,7 +972,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				TARGET_NAME = RemoteImageTests;
@@ -691,6 +984,16 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		5C8E90B32ABF7F1E00181B57 /* Build configuration list for PBXNativeTarget "RemoteImageDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5C8E90B02ABF7F1E00181B57 /* Debug */,
+				5C8E90B12ABF7F1E00181B57 /* Testing */,
+				5C8E90B22ABF7F1E00181B57 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		OBJ_2 /* Build configuration list for PBXProject "RemoteImage" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/RemoteImage.xcodeproj/project.pbxproj
+++ b/RemoteImage.xcodeproj/project.pbxproj
@@ -16,6 +16,9 @@
 		5C4F45582AA4F2C200BB3DC7 /* RemoteImageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F45572AA4F2C200BB3DC7 /* RemoteImageViewModel.swift */; };
 		5C5964DF2ABCC34A009E4AC8 /* Stubby in Frameworks */ = {isa = PBXBuildFile; productRef = 5C5964DE2ABCC34A009E4AC8 /* Stubby */; };
 		5C6968472AAE4F1800F8BA44 /* URLSessionDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C6968462AAE4F1800F8BA44 /* URLSessionDataTests.swift */; };
+		5C8E909C2ABF771E00181B57 /* RemoteImage+InitWithCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8E909B2ABF771E00181B57 /* RemoteImage+InitWithCache.swift */; };
+		5C8E909E2ABF775000181B57 /* RemoteImageViewModel+InitWithCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8E909D2ABF775000181B57 /* RemoteImageViewModel+InitWithCache.swift */; };
+		5C8E90A02ABF78E300181B57 /* RemoteImage+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8E909F2ABF78E300181B57 /* RemoteImage+Helpers.swift */; };
 		5CE5B0062AB38B4A000F79A8 /* Doggo.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 5CA9A4C92AB265CD00A00232 /* Doggo.jpg */; };
 		5CF539AA2ABA666A001E98ED /* RemoteImageStubbedURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF539A92ABA666A001E98ED /* RemoteImageStubbedURL.swift */; };
 		OBJ_24 /* RemoteImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* RemoteImage.swift */; };
@@ -40,6 +43,9 @@
 		5C0A6DD72AA23EE00078B6C9 /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
 		5C4F45572AA4F2C200BB3DC7 /* RemoteImageViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteImageViewModel.swift; sourceTree = "<group>"; };
 		5C6968462AAE4F1800F8BA44 /* URLSessionDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionDataTests.swift; sourceTree = "<group>"; };
+		5C8E909B2ABF771E00181B57 /* RemoteImage+InitWithCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteImage+InitWithCache.swift"; sourceTree = "<group>"; };
+		5C8E909D2ABF775000181B57 /* RemoteImageViewModel+InitWithCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteImageViewModel+InitWithCache.swift"; sourceTree = "<group>"; };
+		5C8E909F2ABF78E300181B57 /* RemoteImage+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteImage+Helpers.swift"; sourceTree = "<group>"; };
 		5CA9A4C92AB265CD00A00232 /* Doggo.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = Doggo.jpg; sourceTree = "<group>"; };
 		5CF539A92ABA666A001E98ED /* RemoteImageStubbedURL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteImageStubbedURL.swift; sourceTree = "<group>"; };
 		5CF5C4FE2AA258FC00B3FC01 /* RemoteImage.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteImage.xctestplan; sourceTree = "<group>"; };
@@ -163,7 +169,10 @@
 			isa = PBXGroup;
 			children = (
 				OBJ_9 /* RemoteImage.swift */,
+				5C8E909F2ABF78E300181B57 /* RemoteImage+Helpers.swift */,
+				5C8E909B2ABF771E00181B57 /* RemoteImage+InitWithCache.swift */,
 				5C4F45572AA4F2C200BB3DC7 /* RemoteImageViewModel.swift */,
+				5C8E909D2ABF775000181B57 /* RemoteImageViewModel+InitWithCache.swift */,
 				5C08C6132ABE22410020D48B /* Extensions */,
 			);
 			name = RemoteImage;
@@ -264,8 +273,11 @@
 			buildActionMask = 0;
 			files = (
 				5C4F45582AA4F2C200BB3DC7 /* RemoteImageViewModel.swift in Sources */,
+				5C8E90A02ABF78E300181B57 /* RemoteImage+Helpers.swift in Sources */,
 				OBJ_24 /* RemoteImage.swift in Sources */,
+				5C8E909C2ABF771E00181B57 /* RemoteImage+InitWithCache.swift in Sources */,
 				5C08C6172ABE22410020D48B /* URLSession+CachedData.swift in Sources */,
+				5C8E909E2ABF775000181B57 /* RemoteImageViewModel+InitWithCache.swift in Sources */,
 				5C08C6162ABE22410020D48B /* Image+PlatformNativeImage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RemoteImage.xcodeproj/xcshareddata/xcschemes/RemoteImageDemo.xcscheme
+++ b/RemoteImage.xcodeproj/xcshareddata/xcschemes/RemoteImageDemo.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5C8E90A42ABF7F1D00181B57"
+               BuildableName = "RemoteImageDemo.app"
+               BlueprintName = "RemoteImageDemo"
+               ReferencedContainer = "container:RemoteImage.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Testing"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5C8E90A42ABF7F1D00181B57"
+            BuildableName = "RemoteImageDemo.app"
+            BlueprintName = "RemoteImageDemo"
+            ReferencedContainer = "container:RemoteImage.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5C8E90A42ABF7F1D00181B57"
+            BuildableName = "RemoteImageDemo.app"
+            BlueprintName = "RemoteImageDemo"
+            ReferencedContainer = "container:RemoteImage.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/RemoteImageDemo/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/RemoteImageDemo/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/RemoteImageDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/RemoteImageDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/RemoteImageDemo/Assets.xcassets/Contents.json
+++ b/RemoteImageDemo/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/RemoteImageDemo/DemosList.swift
+++ b/RemoteImageDemo/DemosList.swift
@@ -24,8 +24,7 @@ struct DemosList: View {
     /// A `RemoteImage` view with custom content.
     case customContent = "Custom content"
 
-    /// Image loaded with a custom `URLSession`, skipping the cache, and using a custom
-    /// phase transition animation.
+    /// Image loaded with a custom `URLSession` and using a custom phase transition animation.
     case customURLSession = "Custom URLSession"
 
     /// Image loaded from a custom cache. If the image is not yet cached, a new `URLSession`
@@ -72,7 +71,13 @@ struct DemosList: View {
       }
 
     case .customPlaceholder:
-      RemoteImage(url: nil) { image in
+      RemoteImage(
+        url: .cuteDoggo,
+        configuration: .init(
+          skipCache: true,
+          transaction: .init(
+            animation: .spring(duration: 1.0).delay(0.5))))
+      { image in
         image.resizable().scaledToFit()
       } placeholder: {
         ZStack {
@@ -118,9 +123,8 @@ struct DemosList: View {
     case .customURLSession:
       RemoteImage(
         url: .cuteDoggo,
-        urlSession: .shared,
+        urlSession: URLSession(configuration: .ephemeral),
         configuration: RemoteImageConfiguration(
-          skipCache: true,
           transaction: Transaction(
             animation: .spring(duration: 1.0).delay(0.5))))
       {
@@ -128,8 +132,20 @@ struct DemosList: View {
       }
 
     case .customCache:
-      RemoteImage(url: .cuteDoggo, cache: .shared) { image in
-        image.resizable().scaledToFit()
+      RemoteImage(
+        url: .cuteDoggo,
+        cache: .inMemoryOnly,
+        configuration: RemoteImageConfiguration(
+          transaction: Transaction(
+            animation: .spring(duration: 1.0).delay(0.5))))
+      {
+        $0.resizable().scaledToFit()
+      } placeholder: {
+        ZStack {
+          Color.black.opacity(0.05)
+          ProgressView()
+        }
+        .aspectRatio(1, contentMode: .fit)
       }
     }
   }
@@ -139,6 +155,10 @@ extension URL {
   fileprivate static let cuteDoggo = URL(string: "https://fastly.picsum.photos/id/237/1000/1000.jpg?hmac=5nME13-xBzl4yi2t1tFev6zsf5IWO2-efZAoXEm9ltc")!
 
   fileprivate static let githubRepo = URL(string: "https://github.com/bdbergeron/RemoteImage")!
+}
+
+extension URLCache {
+  static let inMemoryOnly = URLCache(memoryCapacity: 10_000_000, diskCapacity: 0)
 }
 
 #if DEBUG

--- a/RemoteImageDemo/DemosList.swift
+++ b/RemoteImageDemo/DemosList.swift
@@ -1,0 +1,131 @@
+// Created by Brad Bergeron on 9/23/23.
+
+import RemoteImage
+import SwiftUI
+
+// MARK: - DemosList
+
+struct DemosList: View {
+
+  // MARK: Internal
+
+  var body: some View {
+    NavigationStack {
+      List {
+        ForEach(Variant.allCases, id: \.rawValue) { variant in
+          NavigationLink(variant.rawValue, value: variant)
+        }
+      }
+      .navigationDestination(for: Variant.self) { variant in
+        List {
+          VStack {
+            content(for: variant)
+          }
+          .frame(maxWidth: .infinity)
+          .listRowInsets(.init())
+          .listRowSeparator(.hidden)
+        }
+        .listStyle(.plain)
+        .listSectionSeparator(.hidden)
+        .navigationTitle(variant.rawValue)
+        .navigationBarTitleDisplayMode(.inline)
+      }
+      .navigationTitle("RemoteImage Demos")
+    }
+  }
+
+  // MARK: Private
+
+  private enum Variant: String, CaseIterable {
+    /// A simple `RemoteImage` view.
+    case simple = "Simple"
+
+    /// A simple `RemoteImage` view with modifier closure.
+    case simpleWithModifier = "Simple, with image modifier"
+
+    /// A `RemoteImage` view with a custom placeholder.
+    case customPlaceholder = "Custom placeholder"
+
+    /// A `RemoteImage` view with custom content.
+    case customContent = "Custom content"
+
+    /// Image loaded with a custom `URLSession`, skipping the cache, and using a custom
+    /// phase transition animation.
+    case customURLSession = "Custom URLSession"
+
+    /// Image loaded from a custom cache. If the image is not yet cached, a new `URLSession`
+    /// will be constructed using the `URLSessionConfiguration.default` configuration
+    /// and the provided cache instance.
+    case customCache = "Custom Cache"
+  }
+
+  @ViewBuilder
+  private func content(for variant: Variant) -> some View {
+    switch variant {
+    case .simple:
+      RemoteImage(url: .cuteDoggo)
+
+    case .simpleWithModifier:
+      RemoteImage(url: .cuteDoggo) {
+        $0.resizable().scaledToFit()
+      }
+
+    case .customPlaceholder:
+      RemoteImage(url: nil) { image in
+        image.resizable().scaledToFit()
+      } placeholder: {
+        ProgressView()
+      }
+
+    case .customContent:
+      RemoteImage(url: .githubRepo) { phase in
+        switch phase {
+        case .placeholder:
+          ProgressView()
+        case .loaded(let image):
+          image.resizable().scaledToFit()
+        case .failure:
+          ZStack {
+            Color.yellow.opacity(0.3)
+            Text("Image could not be loaded.")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+      }
+
+    case .customURLSession:
+      RemoteImage(
+        url: .cuteDoggo,
+        urlSession: .shared,
+        configuration: RemoteImageConfiguration(
+          skipCache: true,
+          transaction: Transaction(
+            animation: .easeInOut(duration: 0.5))))
+      {
+        $0.resizable().scaledToFit()
+      }
+
+    case .customCache:
+      RemoteImage(url: .cuteDoggo, cache: .shared) { image in
+        image.resizable().scaledToFit()
+      }
+    }
+  }
+}
+
+extension URL {
+  fileprivate static let cuteDoggo = URL(string: "https://fastly.picsum.photos/id/237/1000/1000.jpg?hmac=5nME13-xBzl4yi2t1tFev6zsf5IWO2-efZAoXEm9ltc")!
+
+  fileprivate static let githubRepo = URL(string: "https://github.com/bdbergeron/RemoteImage")!
+}
+
+#if DEBUG
+// MARK: - DemosListPreviews
+
+struct DemosListPreviews: PreviewProvider {
+  static var previews: some View {
+    DemosList()
+  }
+}
+#endif

--- a/RemoteImageDemo/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/RemoteImageDemo/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/RemoteImageDemo/RemoteImageDemoApp.swift
+++ b/RemoteImageDemo/RemoteImageDemoApp.swift
@@ -1,0 +1,12 @@
+// Created by Brad Bergeron on 9/23/23.
+
+import SwiftUI
+
+@main
+struct RemoteImageDemoApp: App {
+  var body: some Scene {
+    WindowGroup {
+      DemosList()
+    }
+  }
+}

--- a/Sources/RemoteImage/RemoteImage+Helpers.swift
+++ b/Sources/RemoteImage/RemoteImage+Helpers.swift
@@ -1,0 +1,48 @@
+// Created by Brad Bergeron on 9/23/23.
+
+import SwiftUI
+
+extension RemoteImage {
+  @ViewBuilder
+  /// Get an `Image` view for the loaded image, otherwise get an empty placeholder view.
+  /// - Parameter phase: The current ``RemoteImagePhase``.
+  /// - Returns: If the current `phase` is ``RemoteImagePhase/loaded``, returns an `Image` instance with the loaded image.
+  ///   Otherwise, and empty image will be used.
+  static func imageForPhaseOrEmpty(
+    _ phase: RemoteImagePhase)
+    -> Content
+    where
+    Content == _ConditionalContent<Image, Image>
+  {
+    if let image = phase.image {
+      image
+    } else {
+      Image(nativeImage: .init())
+    }
+  }
+
+  @ViewBuilder
+  /// Get an `Image` view for the loaded image, otherwise get the placeholder view.
+  /// - Parameters:
+  ///   - phase: The current ``RemoteImagePhase``.
+  ///   - content: A closure that operates on the loaded image, allowing for customization/manipulation of the loaded image.
+  ///   - placeholder: A view used as the placeholder.
+  /// - Returns: If the current `phase` is ``RemoteImagePhase/loaded``, returns an `Image` instance with the loaded image.
+  ///   Otherwise, return the placeholder view.
+  static func imageForPhaseOrPlaceholder<I, P>(
+    _ phase: RemoteImagePhase,
+    @ViewBuilder content: @escaping (Image) -> I,
+    @ViewBuilder placeholder: @escaping () -> P)
+    -> Content
+    where
+    Content == _ConditionalContent<I, P>,
+    I: View,
+    P: View
+  {
+    if let image = phase.image {
+      content(image)
+    } else {
+      placeholder()
+    }
+  }
+}

--- a/Sources/RemoteImage/RemoteImage+InitWithCache.swift
+++ b/Sources/RemoteImage/RemoteImage+InitWithCache.swift
@@ -81,4 +81,30 @@ extension RemoteImage {
         placeholder: placeholder)
     }
   }
+
+  /// Initialize a new `RemoteImage` instance, using either the fetched remote image or an empty fallback,
+  /// and calling the provided `content` closure to optionally modify the image.
+  /// - Parameters:
+  ///   - url: The URL of the image to display.
+  ///   - cache: Cache to use with the underlying ``URLSession``.
+  ///   - configuration: Configuration options to use. If none is provided, defaults values are used. See ``RemoteImageConfiguration``.
+  ///   - content: A closure that allows for customization/modification of the loaded image.
+  public init<I: View>(
+    url: URL?,
+    cache: URLCache,
+    configuration: RemoteImageConfiguration = .init(),
+    @ViewBuilder content: @escaping (Image) -> I)
+    where
+    Content == _ConditionalContent<I, Image>
+  {
+    self.init(
+      url: url,
+      cache: cache,
+      configuration: configuration)
+    { image in
+      content(image)
+    } placeholder: {
+      Image(nativeImage: .init())
+    }
+  }
 }

--- a/Sources/RemoteImage/RemoteImage+InitWithCache.swift
+++ b/Sources/RemoteImage/RemoteImage+InitWithCache.swift
@@ -1,0 +1,84 @@
+// Created by Brad Bergeron on 9/23/23.
+
+import SwiftUI
+
+// MARK: - RemoteImage + initWithCache
+
+extension RemoteImage {
+
+  /// Initialize a new `RemoteImage` instance.
+  ///
+  /// A ``URLSession`` will be constructed using the ``URLSessionConfiguration.default`` configuration and the specified ``cache``.
+  /// - Parameters:
+  ///   - url: The URL of the image to display.
+  ///   - cache: Cache to use with the underlying ``URLSession``.
+  ///   - configuration: Configuration options to use. If none is provided, defaults values are used. See ``RemoteImageConfiguration``.
+  ///   - content: A closure that takes the load phase as an input, and returns the view to display for the specified phase.
+  public init(
+    url: URL?,
+    cache: URLCache,
+    configuration: RemoteImageConfiguration = .init(),
+    @ViewBuilder content: @escaping (RemoteImagePhase) -> Content)
+  {
+    self.init(
+      model: RemoteImageViewModel(
+        url: url,
+        cache: cache,
+        configuration: configuration),
+      content: content)
+  }
+
+  /// Initialize a new `RemoteImage` instance using either the fetched remote image or an empty fallback.
+  ///
+  /// A ``URLSession`` will be constructed using the ``URLSessionConfiguration.default`` configuration and the specified ``cache``.
+  /// - Parameters:
+  ///   - url: The URL of the image to display.
+  ///   - cache: Cache to use with the underlying ``URLSession``.
+  ///   - configuration: Configuration options to use. If none is provided, defaults values are used. See ``RemoteImageConfiguration``.
+  public init(
+    url: URL?,
+    cache: URLCache,
+    configuration: RemoteImageConfiguration = .init())
+    where
+    Content == _ConditionalContent<Image, Image>
+  {
+    self.init(
+      url: url,
+      cache: cache,
+      configuration: configuration,
+      content: Self.imageForPhaseOrEmpty)
+  }
+
+  /// Initialize a new `RemoteImage` instance using a custom placeholder.
+  ///
+  /// A ``URLSession`` will be constructed using the ``URLSessionConfiguration.default`` configuration and the specified ``cache``.
+  /// - Parameters:
+  ///   - url: The URL of the image to display.
+  ///   - cache: Cache to use with the underlying ``URLSession``.
+  ///   - configuration: Configuration options to use. If none is provided, defaults values are used. See ``RemoteImageConfiguration``.
+  ///   - content: A closure that takes the loaded image as an input, and returns the view to show. You can return the image directly, or modify it as needed
+  ///     before returning it.
+  ///   - placeholder: A closure that returns the view to show until the load operation completes successfully.
+  public init<I, P>(
+    url: URL?,
+    cache: URLCache,
+    configuration: RemoteImageConfiguration = .init(),
+    @ViewBuilder content: @escaping (Image) -> I,
+    @ViewBuilder placeholder: @escaping () -> P)
+    where
+    Content == _ConditionalContent<I, P>,
+    I: View,
+    P: View
+  {
+    self.init(
+      url: url,
+      cache: cache,
+      configuration: configuration)
+    { phase in
+      Self.imageForPhaseOrPlaceholder(
+        phase,
+        content: content,
+        placeholder: placeholder)
+    }
+  }
+}

--- a/Sources/RemoteImage/RemoteImage.swift
+++ b/Sources/RemoteImage/RemoteImage.swift
@@ -145,6 +145,32 @@ public struct RemoteImage<Content: View>: View {
         placeholder: placeholder)
     }
   }
+  
+  /// Initialize a new `RemoteImage` instance, using either the fetched remote image or an empty fallback, 
+  /// and calling the provided `content` closure to optionally modify the image.
+  /// - Parameters:
+  ///   - url: The URL of the image to display.
+  ///   - urlSession: Optional ``URLSession`` to use for fetching the remote image. If not specified, the ``URLSession.shared`` singleton is used.
+  ///   - configuration: Configuration options to use. If none is provided, defaults values are used. See ``RemoteImageConfiguration``.
+  ///   - content: A closure that allows for customization/modification of the loaded image.
+  public init<I: View>(
+    url: URL?,
+    urlSession: URLSession = .shared,
+    configuration: RemoteImageConfiguration = .init(),
+    @ViewBuilder content: @escaping (_ image: Image) -> I)
+    where
+    Content == _ConditionalContent<I, Image>
+  {
+    self.init(
+      url: url,
+      urlSession: urlSession,
+      configuration: configuration)
+    { image in
+      content(image)
+    } placeholder: {
+      Image(nativeImage: .init())
+    }
+  }
 
   // MARK: Public
 

--- a/Sources/RemoteImage/RemoteImage.swift
+++ b/Sources/RemoteImage/RemoteImage.swift
@@ -88,12 +88,12 @@ public struct RemoteImage<Content: View>: View {
     configuration: RemoteImageConfiguration = .init(),
     @ViewBuilder content: @escaping (RemoteImagePhase) -> Content)
   {
-    _model = .init(
-      wrappedValue: RemoteImageViewModel(
+    self.init(
+      model: RemoteImageViewModel(
         url: url,
         urlSession: urlSession,
-        configuration: configuration))
-    self.content = content
+        configuration: configuration),
+      content: content)
   }
 
   /// Initialize a new `RemoteImage` instance using either the fetched remote image or an empty fallback.
@@ -162,6 +162,14 @@ public struct RemoteImage<Content: View>: View {
 
   // MARK: Internal
 
+  init(
+    model: RemoteImageViewModel,
+    @ViewBuilder content: @escaping (RemoteImagePhase) -> Content)
+  {
+    _model = .init(wrappedValue: model)
+    self.content = content
+  }
+
   @StateObject var model: RemoteImageViewModel
 
   var didAppear: ((Self) -> Void)?
@@ -170,118 +178,6 @@ public struct RemoteImage<Content: View>: View {
 
   private var content: (RemoteImagePhase) -> Content
 
-  @ViewBuilder
-  private static func imageForPhaseOrEmpty(
-    _ phase: RemoteImagePhase)
-    -> Content
-    where
-    Content == _ConditionalContent<Image, Image>
-  {
-    if let image = phase.image {
-      image
-    } else {
-      Image(nativeImage: .init())
-    }
-  }
-
-  @ViewBuilder
-  private static func imageForPhaseOrPlaceholder<I, P>(
-    _ phase: RemoteImagePhase,
-    @ViewBuilder content: @escaping (Image) -> I,
-    @ViewBuilder placeholder: @escaping () -> P)
-    -> Content
-    where
-    Content == _ConditionalContent<I, P>,
-    I: View,
-    P: View
-  {
-    if let image = phase.image {
-      content(image)
-    } else {
-      placeholder()
-    }
-  }
-}
-
-// MARK: initWithCache
-
-extension RemoteImage {
-
-  /// Initialize a new `RemoteImage` instance.
-  ///
-  /// A ``URLSession`` will be constructed using the ``URLSessionConfiguration.default`` configuration and the specified ``cache``.
-  /// - Parameters:
-  ///   - url: The URL of the image to display.
-  ///   - cache: Cache to use with the underlying ``URLSession``.
-  ///   - configuration: Configuration options to use. If none is provided, defaults values are used. See ``RemoteImageConfiguration``.
-  ///   - content: A closure that takes the load phase as an input, and returns the view to display for the specified phase.
-  public init(
-    url: URL?,
-    cache: URLCache,
-    configuration: RemoteImageConfiguration = .init(),
-    @ViewBuilder content: @escaping (RemoteImagePhase) -> Content)
-  {
-    _model = .init(
-      wrappedValue: RemoteImageViewModel(
-        url: url,
-        cache: cache,
-        configuration: configuration))
-    self.content = content
-  }
-
-  /// Initialize a new `RemoteImage` instance using either the fetched remote image or an empty fallback.
-  ///
-  /// A ``URLSession`` will be constructed using the ``URLSessionConfiguration.default`` configuration and the specified ``cache``.
-  /// - Parameters:
-  ///   - url: The URL of the image to display.
-  ///   - cache: Cache to use with the underlying ``URLSession``.
-  ///   - configuration: Configuration options to use. If none is provided, defaults values are used. See ``RemoteImageConfiguration``.
-  public init(
-    url: URL?,
-    cache: URLCache,
-    configuration: RemoteImageConfiguration = .init())
-    where
-    Content == _ConditionalContent<Image, Image>
-  {
-    self.init(
-      url: url,
-      cache: cache,
-      configuration: configuration,
-      content: Self.imageForPhaseOrEmpty)
-  }
-
-  /// Initialize a new `RemoteImage` instance using a custom placeholder.
-  ///
-  /// A ``URLSession`` will be constructed using the ``URLSessionConfiguration.default`` configuration and the specified ``cache``.
-  /// - Parameters:
-  ///   - url: The URL of the image to display.
-  ///   - cache: Cache to use with the underlying ``URLSession``.
-  ///   - configuration: Configuration options to use. If none is provided, defaults values are used. See ``RemoteImageConfiguration``.
-  ///   - content: A closure that takes the loaded image as an input, and returns the view to show. You can return the image directly, or modify it as needed
-  ///     before returning it.
-  ///   - placeholder: A closure that returns the view to show until the load operation completes successfully.
-  public init<I, P>(
-    url: URL?,
-    cache: URLCache,
-    configuration: RemoteImageConfiguration = .init(),
-    @ViewBuilder content: @escaping (Image) -> I,
-    @ViewBuilder placeholder: @escaping () -> P)
-    where
-    Content == _ConditionalContent<I, P>,
-    I: View,
-    P: View
-  {
-    self.init(
-      url: url,
-      cache: cache,
-      configuration: configuration)
-    { phase in
-      Self.imageForPhaseOrPlaceholder(
-        phase,
-        content: content,
-        placeholder: placeholder)
-    }
-  }
 }
 
 #if DEBUG

--- a/Sources/RemoteImage/RemoteImageViewModel+InitWithCache.swift
+++ b/Sources/RemoteImage/RemoteImageViewModel+InitWithCache.swift
@@ -1,0 +1,30 @@
+// Created by Brad Bergeron on 9/23/23.
+
+import SwiftUI
+
+// MARK: - RemoteImageViewModel + initWithCache
+
+extension RemoteImageViewModel {
+  /// Create a new ``RemoteImageViewModel`` instance.
+  ///
+  /// A ``URLSession`` will be constructed using the ``URLSessionConfiguration.default`` configuration and the specified ``cache``.
+  /// - Parameters:
+  ///   - url: Image URL.
+  ///   - cache: Cache instance to use.
+  ///   - configuration: A ``RemoteImageConfiguration`` object to use for configuring this model.
+  convenience init(
+    url: URL?,
+    cache: URLCache,
+    configuration: RemoteImageConfiguration)
+  {
+    self.init(
+      url: url,
+      urlSession: URLSession(
+        configuration: {
+          let configuration = URLSessionConfiguration.default
+          configuration.urlCache = cache
+          return configuration
+        }()),
+      configuration: configuration)
+  }
+}

--- a/Sources/RemoteImage/RemoteImageViewModel.swift
+++ b/Sources/RemoteImage/RemoteImageViewModel.swift
@@ -169,30 +169,3 @@ final class RemoteImageViewModel: ObservableObject {
   }
 
 }
-
-// MARK: initWithCache
-
-extension RemoteImageViewModel {
-  /// Create a new ``RemoteImageViewModel`` instance.
-  ///
-  /// A ``URLSession`` will be constructed using the ``URLSessionConfiguration.default`` configuration and the specified ``cache``.
-  /// - Parameters:
-  ///   - url: Image URL.
-  ///   - cache: Cache instance to use.
-  ///   - configuration: A ``RemoteImageConfiguration`` object to use for configuring this model.
-  convenience init(
-    url: URL?,
-    cache: URLCache,
-    configuration: RemoteImageConfiguration)
-  {
-    self.init(
-      url: url,
-      urlSession: URLSession(
-        configuration: {
-          let configuration = URLSessionConfiguration.default
-          configuration.urlCache = cache
-          return configuration
-        }()),
-      configuration: configuration)
-  }
-}


### PR DESCRIPTION
Add a new demo app to the Xcode project, showcasing various `RemoteImage` usages.

Also adds a new `RemoteImage` initializer that allows for simple usage with just a `URL` but with a closure to modify the loaded image:
```swift
RemoteImage(url: imageURL) {
  $0.resizable().scaledToFit()
}
```