### PR TITLE
Add another new initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,42 +27,31 @@ Check out the `RemoteImage Demos` app in the Xcode project to see some live exma
 let imageURL: URL?
 
 /// A simple `RemoteImage` view.
-#Preview("Simple") {
-  RemoteImage(url: imageURL)
-}
+RemoteImage(url: imageURL)
 
 /// A simple `RemoteImage` view with modifier closure.
-#Preview("Simple, with image modifier") {
-  RemoteImage(url: imageURL) {
-    $0.resizable().scaledToFit()
-  }
+RemoteImage(url: imageURL) {
+  $0.resizable().scaledToFit()
 }
 
-/// A `RemoteImage` view with a custom placeholder.
-#Preview("Custom placeholder") {
-  RemoteImage(url: imageURL) {
-    $0.resizable().scaledToFit()
-  } placeholder: {
-    ProgressView()
-  }
+/// A `RemoteImage` view with a custom placeholder view.
+RemoteImage(url: imageURL) {
+  $0.resizable().scaledToFit()
+} placeholder: {
+  ProgressView()
 }
 
-/// A `RemoteImage` view with custom content.
-#Preview("Custom content") {
-  RemoteImage(url: imageURL) { phase in
-    switch phase {
-    case .placeholder:
-      ProgressView()
-    case .loaded(let image):
-      image.resizable().scaledToFit()
-    case .failure:
-      ZStack {
-        Color.yellow.opacity(0.3)
-        Text("Image could not be loaded.")
-          .font(.caption)
-          .foregroundStyle(.secondary)
-      }
-    }
+/// A `RemoteImage` view with custom placeholder and failure views.
+RemoteImage(url: imageURL) {
+  $0.resizable().scaledToFit()
+} placeholder: {
+  ProgressView()
+} failure: { error in
+  ZStack {
+    Color.yellow.opacity(0.3)
+    Text("Image could not be loaded.")
+      .font(.caption)
+      .foregroundStyle(.secondary)
   }
 }
 ```
@@ -75,24 +64,25 @@ let urlSession = URLSession(configuration: .ephemeral)
 let imageCache = URLCache(memoryCapacity: 10_000_000, diskCapacity: 0)
 
 /// Image loaded with a custom `URLSession` and using a custom phase transition animation.
-#Preview("Custom URLSession") {
-  RemoteImage(
-    url: imageURL,
-    urlSession: urlSession,
-    configuration: RemoteImageConfiguration(
-      transaction: Transaction(
-        animation: .spring(duration: 1.0).delay(0.5))))
-  {
-    $0.resizable().scaledToFit()
-  }
+RemoteImage(
+  url: imageURL,
+  urlSession: urlSession,
+  configuration: RemoteImageConfiguration(
+    transaction: Transaction(
+      animation: .spring(duration: 1.0).delay(0.5))))
+{
+  $0.resizable().scaledToFit()
 }
 
 /// Image loaded from a custom cache. If the image is not yet cached, a new `URLSession`
 /// will be constructed using the `URLSessionConfiguration.default` configuration
 /// and the provided cache instance.
-#Preview("Custom URLCache") {
-  RemoteImage(url: imageURL, cache: imageCache) {
-    $0.resizable().scaledToFit()
+RemoteImage(url: imageURL, cache: imageCache) {
+  $0.resizable().scaledToFit()
+} placeholder: {
+  ZStack {
+    Color.black.opacity(0.05)
+    ProgressView()
   }
 }
 ```

--- a/RemoteImageDemo/DemosList.swift
+++ b/RemoteImageDemo/DemosList.swift
@@ -93,31 +93,28 @@ struct DemosList: View {
         configuration: RemoteImageConfiguration(
           transaction: Transaction(
             animation: .spring(duration: 1.0).delay(0.5))))
-      { phase in
-        switch phase {
-        case .placeholder:
-          ZStack {
-            Color.black.opacity(0.05)
-            ProgressView()
-          }
-          .aspectRatio(1, contentMode: .fit)
-        case .loaded(let image):
-          image.resizable().scaledToFit()
-        case .failure:
-          ZStack {
-            Color.yellow.opacity(0.3)
-            VStack(spacing: 12) {
-              Image(systemName: "photo")
-                .resizable()
-                .scaledToFit()
-                .frame(width: 32)
-              Text("Image could not be loaded.")
-            }
-            .font(.headline.weight(.regular))
-            .foregroundStyle(.secondary)
-          }
-          .aspectRatio(1, contentMode: .fit)
+      {
+        $0.resizable().scaledToFit()
+      } placeholder: {
+        ZStack {
+          Color.black.opacity(0.05)
+          ProgressView()
         }
+        .aspectRatio(1, contentMode: .fit)
+      } failure: { _ in
+        ZStack {
+          Color.yellow.opacity(0.3)
+          VStack(spacing: 12) {
+            Image(systemName: "photo")
+              .resizable()
+              .scaledToFit()
+              .frame(width: 32)
+            Text("Image could not be loaded.")
+          }
+          .font(.headline.weight(.regular))
+          .foregroundStyle(.secondary)
+        }
+        .aspectRatio(1, contentMode: .fit)
       }
 
     case .customURLSession:

--- a/Sources/RemoteImage/RemoteImage+Helpers.swift
+++ b/Sources/RemoteImage/RemoteImage+Helpers.swift
@@ -3,12 +3,12 @@
 import SwiftUI
 
 extension RemoteImage {
-  @ViewBuilder
   /// Get an `Image` view for the loaded image, otherwise get an empty placeholder view.
   /// - Parameter phase: The current ``RemoteImagePhase``.
   /// - Returns: If the current `phase` is ``RemoteImagePhase/loaded``, returns an `Image` instance with the loaded image.
   ///   Otherwise, and empty image will be used.
-  static func imageForPhaseOrEmpty(
+  @ViewBuilder
+  static func imageOrEmpty(
     _ phase: RemoteImagePhase)
     -> Content
     where
@@ -21,15 +21,15 @@ extension RemoteImage {
     }
   }
 
-  @ViewBuilder
-  /// Get an `Image` view for the loaded image, otherwise get the placeholder view.
+  /// Get a view for the loaded image. If the image is loading, the placeholder view is shown.
   /// - Parameters:
   ///   - phase: The current ``RemoteImagePhase``.
   ///   - content: A closure that operates on the loaded image, allowing for customization/manipulation of the loaded image.
   ///   - placeholder: A view used as the placeholder.
   /// - Returns: If the current `phase` is ``RemoteImagePhase/loaded``, returns an `Image` instance with the loaded image.
   ///   Otherwise, return the placeholder view.
-  static func imageForPhaseOrPlaceholder<I, P>(
+  @ViewBuilder
+  static func contentForPhase<I, P>(
     _ phase: RemoteImagePhase,
     @ViewBuilder content: @escaping (Image) -> I,
     @ViewBuilder placeholder: @escaping () -> P)
@@ -46,8 +46,7 @@ extension RemoteImage {
     }
   }
 
-  @ViewBuilder
-  /// Get an `Image` view for the loaded image, otherwise get the placeholder view.
+  /// Get a view for the loaded image. If the image is loading, the placeholder view is shown. If the image failed to load, the failure view is shown.
   /// - Parameters:
   ///   - phase: The current ``RemoteImagePhase``.
   ///   - content: A closure that operates on the loaded image, allowing for customization/manipulation of the loaded image.
@@ -55,6 +54,7 @@ extension RemoteImage {
   ///   - failure: A view used if the image fails to load.
   /// - Returns: If the current `phase` is ``RemoteImagePhase/loaded``, returns an `Image` instance with the loaded image.
   ///   Otherwise, return the placeholder view.
+  @ViewBuilder
   static func contentForPhase<I, P, F>(
     _ phase: RemoteImagePhase,
     @ViewBuilder content: @escaping (Image) -> I,

--- a/Sources/RemoteImage/RemoteImage+Helpers.swift
+++ b/Sources/RemoteImage/RemoteImage+Helpers.swift
@@ -45,4 +45,35 @@ extension RemoteImage {
       placeholder()
     }
   }
+
+  @ViewBuilder
+  /// Get an `Image` view for the loaded image, otherwise get the placeholder view.
+  /// - Parameters:
+  ///   - phase: The current ``RemoteImagePhase``.
+  ///   - content: A closure that operates on the loaded image, allowing for customization/manipulation of the loaded image.
+  ///   - placeholder: A view used as the placeholder.
+  ///   - failure: A view used if the image fails to load.
+  /// - Returns: If the current `phase` is ``RemoteImagePhase/loaded``, returns an `Image` instance with the loaded image.
+  ///   Otherwise, return the placeholder view.
+  static func contentForPhase<I, P, F>(
+    _ phase: RemoteImagePhase,
+    @ViewBuilder content: @escaping (Image) -> I,
+    @ViewBuilder placeholder: @escaping () -> P,
+    @ViewBuilder failure: @escaping (Error) -> F)
+    -> Content
+    where
+    Content == _ConditionalContent<_ConditionalContent<P, I>, F>,
+    I: View,
+    P: View,
+    F: View
+  {
+    switch phase {
+    case .placeholder:
+      placeholder()
+    case .loaded(let image):
+      content(image)
+    case .failure(let error):
+      failure(error)
+    }
+  }
 }

--- a/Sources/RemoteImage/RemoteImage+InitWithCache.swift
+++ b/Sources/RemoteImage/RemoteImage+InitWithCache.swift
@@ -46,11 +46,11 @@ extension RemoteImage {
       url: url,
       cache: cache,
       configuration: configuration,
-      content: Self.imageForPhaseOrEmpty)
+      content: Self.imageOrEmpty)
   }
 
-  /// Initialize a new `RemoteImage` instance, using either the fetched remote image or an empty fallback,
-  /// and calling the provided `content` closure to optionally modify the image.
+  /// Initialize a new `RemoteImage` instance, using either the fetched remote image or an empty fallback, and calling the provided `content` closure
+  /// to optionally modify the image.
   ///
   /// A ``URLSession`` will be constructed using the ``URLSessionConfiguration.default`` configuration and the specified ``cache``.
   /// - Parameters:
@@ -70,10 +70,13 @@ extension RemoteImage {
       url: url,
       cache: cache,
       configuration: configuration)
-    { image in
-      content(image)
-    } placeholder: {
-      Image(nativeImage: .init())
+    { phase in
+      Self.contentForPhase(
+        phase,
+        content: content,
+        placeholder: {
+          Image(nativeImage: .init())
+        })
     }
   }
 
@@ -103,7 +106,7 @@ extension RemoteImage {
       cache: cache,
       configuration: configuration)
     { phase in
-      Self.imageForPhaseOrPlaceholder(
+      Self.contentForPhase(
         phase,
         content: content,
         placeholder: placeholder)

--- a/Sources/RemoteImage/RemoteImage+InitWithCache.swift
+++ b/Sources/RemoteImage/RemoteImage+InitWithCache.swift
@@ -51,6 +51,8 @@ extension RemoteImage {
 
   /// Initialize a new `RemoteImage` instance, using either the fetched remote image or an empty fallback,
   /// and calling the provided `content` closure to optionally modify the image.
+  ///
+  /// A ``URLSession`` will be constructed using the ``URLSessionConfiguration.default`` configuration and the specified ``cache``.
   /// - Parameters:
   ///   - url: The URL of the image to display.
   ///   - cache: Cache to use with the underlying ``URLSession``.
@@ -108,7 +110,10 @@ extension RemoteImage {
     }
   }
   
-  /// Initialize a new `RemoteImage` instance using a custom placeholder and failure view.
+  /// Initialize a new `RemoteImage` instance, calling the provided `content` closure to optionally modify the loaded image.
+  /// While the image loads, the `placeholder` is shown. If the image fails to load, `failure` is shown.
+  ///
+  /// A ``URLSession`` will be constructed using the ``URLSessionConfiguration.default`` configuration and the specified ``cache``.
   /// - Parameters:
   ///   - url: The URL of the image to display.
   ///   - cache: Cache to use with the underlying ``URLSession``.

--- a/Sources/RemoteImage/RemoteImage.swift
+++ b/Sources/RemoteImage/RemoteImage.swift
@@ -112,11 +112,11 @@ public struct RemoteImage<Content: View>: View {
       url: url,
       urlSession: urlSession,
       configuration: configuration,
-      content: Self.imageForPhaseOrEmpty)
+      content: Self.imageOrEmpty)
   }
 
-  /// Initialize a new `RemoteImage` instance, using either the fetched remote image or an empty fallback,
-  /// and calling the provided `content` closure to optionally modify the image.
+  /// Initialize a new `RemoteImage` instance, using either the fetched remote image or an empty fallback, and calling the provided `content` closure
+  /// to optionally modify the image.
   /// - Parameters:
   ///   - url: The URL of the image to display.
   ///   - urlSession: Optional ``URLSession`` to use for fetching the remote image. If not specified, the ``URLSession.shared`` singleton is used.
@@ -134,10 +134,13 @@ public struct RemoteImage<Content: View>: View {
       url: url,
       urlSession: urlSession,
       configuration: configuration)
-    { image in
-      content(image)
-    } placeholder: {
-      Image(nativeImage: .init())
+    { phase in
+      Self.contentForPhase(
+        phase,
+        content: content,
+        placeholder: {
+          Image(nativeImage: .init())
+        })
     }
   }
 
@@ -165,7 +168,7 @@ public struct RemoteImage<Content: View>: View {
       urlSession: urlSession,
       configuration: configuration)
     { phase in
-      Self.imageForPhaseOrPlaceholder(
+      Self.contentForPhase(
         phase,
         content: content,
         placeholder: placeholder)

--- a/Sources/RemoteImage/RemoteImage.swift
+++ b/Sources/RemoteImage/RemoteImage.swift
@@ -115,6 +115,32 @@ public struct RemoteImage<Content: View>: View {
       content: Self.imageForPhaseOrEmpty)
   }
 
+  /// Initialize a new `RemoteImage` instance, using either the fetched remote image or an empty fallback,
+  /// and calling the provided `content` closure to optionally modify the image.
+  /// - Parameters:
+  ///   - url: The URL of the image to display.
+  ///   - urlSession: Optional ``URLSession`` to use for fetching the remote image. If not specified, the ``URLSession.shared`` singleton is used.
+  ///   - configuration: Configuration options to use. If none is provided, defaults values are used. See ``RemoteImageConfiguration``.
+  ///   - content: A closure that allows for customization/modification of the loaded image.
+  public init<I: View>(
+    url: URL?,
+    urlSession: URLSession = .shared,
+    configuration: RemoteImageConfiguration = .init(),
+    @ViewBuilder content: @escaping (Image) -> I)
+    where
+    Content == _ConditionalContent<I, Image>
+  {
+    self.init(
+      url: url,
+      urlSession: urlSession,
+      configuration: configuration)
+    { image in
+      content(image)
+    } placeholder: {
+      Image(nativeImage: .init())
+    }
+  }
+
   /// Initialize a new `RemoteImage` instance using a custom placeholder.
   /// - Parameters:
   ///   - url: The URL of the image to display.
@@ -145,30 +171,40 @@ public struct RemoteImage<Content: View>: View {
         placeholder: placeholder)
     }
   }
-  
-  /// Initialize a new `RemoteImage` instance, using either the fetched remote image or an empty fallback, 
-  /// and calling the provided `content` closure to optionally modify the image.
+
+  /// Initialize a new `RemoteImage` instance using a custom placeholder and failure view.
   /// - Parameters:
   ///   - url: The URL of the image to display.
+  ///   - cache: Cache to use with the underlying ``URLSession``.
   ///   - urlSession: Optional ``URLSession`` to use for fetching the remote image. If not specified, the ``URLSession.shared`` singleton is used.
   ///   - configuration: Configuration options to use. If none is provided, defaults values are used. See ``RemoteImageConfiguration``.
-  ///   - content: A closure that allows for customization/modification of the loaded image.
-  public init<I: View>(
+  ///   - content: A closure that takes the loaded image as an input, and returns the view to show. You can return the image directly, or modify it as needed
+  ///     before returning it.
+  ///   - placeholder: A closure that returns the view to show until the load operation completes successfully.
+  ///   - failure: A closure that returns a view to show if the image fails to load.
+  public init<I, P, F>(
     url: URL?,
     urlSession: URLSession = .shared,
     configuration: RemoteImageConfiguration = .init(),
-    @ViewBuilder content: @escaping (_ image: Image) -> I)
+    @ViewBuilder content: @escaping (Image) -> I,
+    @ViewBuilder placeholder: @escaping () -> P,
+    @ViewBuilder failure: @escaping (Error) -> F)
     where
-    Content == _ConditionalContent<I, Image>
+    Content == _ConditionalContent<_ConditionalContent<P, I>, F>,
+    I: View,
+    P: View,
+    F: View
   {
     self.init(
       url: url,
       urlSession: urlSession,
       configuration: configuration)
-    { image in
-      content(image)
-    } placeholder: {
-      Image(nativeImage: .init())
+    { phase in
+      Self.contentForPhase(
+        phase,
+        content: content,
+        placeholder: placeholder,
+        failure: failure)
     }
   }
 

--- a/Sources/RemoteImage/RemoteImage.swift
+++ b/Sources/RemoteImage/RemoteImage.swift
@@ -172,7 +172,8 @@ public struct RemoteImage<Content: View>: View {
     }
   }
 
-  /// Initialize a new `RemoteImage` instance using a custom placeholder and failure view.
+  /// Initialize a new `RemoteImage` instance, calling the provided `content` closure to optionally modify the loaded image.
+  /// While the image loads, the `placeholder` is shown. If the image fails to load, `failure` is shown.
   /// - Parameters:
   ///   - url: The URL of the image to display.
   ///   - cache: Cache to use with the underlying ``URLSession``.

--- a/Sources/RemoteImage/RemoteImageViewModel.swift
+++ b/Sources/RemoteImage/RemoteImageViewModel.swift
@@ -61,7 +61,7 @@ final class RemoteImageViewModel: ObservableObject {
   let logger: Logger?
 
   /// The current image phase.
-  @Published private(set) var phase: RemoteImagePhase = .placeholder
+  @Published var phase: RemoteImagePhase = .placeholder
 
   var loadingTask: Task<Void, Swift.Error>?
 
@@ -117,7 +117,7 @@ final class RemoteImageViewModel: ObservableObject {
   /// - Returns: An ``Image`` instance.
   func createImage(with data: Data) throws -> Image {
     guard let image = PlatformNativeImage(data: data, scale: scale) else {
-      logger?.error("Could not create a \(PlatformNativeImage.self) instance from data (\(data)).")
+      logger?.error("Could not create a \(PlatformNativeImage.self) instance from data (\(data, privacy: .public)).")
       throw Error.invalidImageData
     }
     return Image(nativeImage: image)
@@ -134,21 +134,21 @@ final class RemoteImageViewModel: ObservableObject {
       return
     }
     // Perform network fetch.
-    logger?.debug("Loading image from \(url)...")
+    logger?.debug("Loading image from \(url, privacy: .public)...")
     do {
       let (data, _, didLoadFromCache) = try await urlSession.cachedData(from: url, skipCache: skipCache)
       try Task.checkCancellation()
-      logger?.debug("Image loaded from \(url) with \(data.count) bytes. From cache: \(String(describing: didLoadFromCache)).")
+      logger?.debug("Image loaded from \(url) with \(data.count) bytes. From cache: \(String(describing: didLoadFromCache), privacy: .public).")
       let image = try createImage(with: data)
       try Task.checkCancellation()
       let disableAnimation = didLoadFromCache && disableTransactionWithCachedResponse
-      logger?.debug("Setting phase to .loaded for \(url). Animated: \(String(describing: !disableAnimation)).")
+      logger?.debug("Setting phase to .loaded for \(url). Animated: \(String(describing: !disableAnimation), privacy: .public).")
       setPhase(.loaded(image), animated: !disableAnimation)
     } catch URLError.cancelled {
-      logger?.debug("Cancelled loading image from \(url).")
+      logger?.debug("Cancelled loading image from \(url, privacy: .public).")
       setPhase(.placeholder, animated: false)
     } catch {
-      logger?.error("Failed to load image from \(url): \(error.localizedDescription)")
+      logger?.error("Failed to load image from \(url): \(error.localizedDescription, privacy: .public)")
       setPhase(.failure(error), animated: true)
     }
     loadingTask = nil

--- a/Tests/RemoteImageTests/Helpers/Helpers.swift
+++ b/Tests/RemoteImageTests/Helpers/Helpers.swift
@@ -44,7 +44,8 @@ extension URLSession {
   ///   - url: Image URL to fetch.
   ///   - cache: Cache instance to use with URLSession.
   /// - Returns: An ``Image`` instance of the fetched image.
-  @discardableResult func fetchImage(from url: URL) async throws -> Image {
+  @discardableResult 
+  func fetchImage(from url: URL) async throws -> Image {
     let (data, _) = try await data(from: url)
     XCTAssertFalse(data.isEmpty)
     let image = try XCTUnwrap(PlatformNativeImage(data: data))
@@ -56,7 +57,8 @@ extension Image {
   /// Get the data representation of this `Image` instance.
   /// - Parameter scale: Display scale to render the image at.
   /// - Returns: A `Data` representation of this `Image` view.
-  @MainActor func dataRepresentation(scale: CGFloat = 1.0) -> Data? {
+  @MainActor 
+  func dataRepresentation(scale: CGFloat = 1.0) -> Data? {
     let renderer = ImageRenderer(content: self)
     renderer.scale = scale
     #if os(iOS)


### PR DESCRIPTION
Adds a convenience initializer with closures for content, placeholder, and failure states. This is little more ergonomic than switching over a returned `phase` for most use cases.

```swift
RemoteImage(url: imageURL) {
  $0.resizable().scaledToFit()
} placeholder: {
  ProgressView()
} failure: { error in
  ZStack {
    Color.yellow.opacity(0.3)
    Text("Image could not be loaded.")
      .font(.caption)
      .foregroundStyle(.secondary)
  }
}
```