### PR TITLE
Swift 5.9 and strict concurrency support

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,144 @@
+# Exclude checkout directories for common package managers
+--exclude .build
+
+# options
+--swift-version 5.9
+--language-mode 5
+--self remove # redundantSelf
+--import-grouping testable-bottom # sortedImports
+--trailing-commas multi-element-lists # trailingCommas
+--trim-whitespace always # trailingSpace
+--indent 2 #indent
+--ifdef no-indent #indent
+--indent-strings true #indent
+--wrap-arguments before-first # wrapArguments
+--wrap-parameters before-first # wrapArguments
+--wrap-collections before-first # wrapArguments
+--wrap-conditions before-first # wrapArguments
+--wrap-return-type never #wrapArguments
+--wrap-effects never #wrapArguments
+--closing-paren balanced # wrapArguments
+--call-site-paren balanced # wrapArguments
+--wrap-type-aliases before-first # wrapArguments
+--allow-partial-wrapping false # wrapArguments
+--func-attributes prev-line # wrapAttributes
+--computed-var-attributes prev-line # wrapAttributes
+--stored-var-attributes same-line # wrapAttributes
+--complex-attributes prev-line # wrapAttributes
+--type-attributes prev-line # wrapAttributes
+--wrap-ternary before-operators # wrap
+--wrap-string-interpolation preserve # wrap
+--mark-struct-threshold 20 # organizeDeclarations
+--mark-enum-threshold 20 # organizeDeclarations
+--organize-types class,struct,enum,extension,actor,protocol # organizeDeclarations
+--visibility-order beforeMarks,instanceLifecycle,open,public,package,internal,fileprivate,private # organizeDeclarations
+--type-order nestedType,staticProperty,staticPropertyWithBody,classPropertyWithBody,swiftUIPropertyWrapper,instanceProperty,instancePropertyWithBody,staticMethod,classMethod,instanceMethod # organizeDeclarations
+--sort-swiftui-properties first-appearance-sort #organizeDeclarations
+--type-body-marks remove #organizeDeclarations
+--extension-acl on-declarations # extensionAccessControl
+--pattern-let inline # hoistPatternLet
+--property-types inferred # redundantType, propertyTypes
+--type-blank-lines preserve # blankLinesAtStartOfScope, blankLinesAtEndOfScope
+--empty-braces spaced # emptyBraces
+--ranges preserve # spaceAroundOperators
+--operator-func no-space # spaceAroundOperators
+--some-any disabled # opaqueGenericParameters
+--else-position same-line # elseOnSameLine
+--guard-else next-line # elseOnSameLine
+--single-line-for-each convert # preferForLoop
+--short-optionals always # typeSugar
+--semicolons never # semicolons
+--doc-comments preserve # docComments
+
+# Customized default modifier order to put `override` after access control
+--modifier-order private,fileprivate,internal,package,public,open,private(set),fileprivate(set),internal(set),package(set),public(set),open(set),override,final,dynamic,optional,required,convenience,indirect,isolated,nonisolated,nonisolated(unsafe),lazy,weak,unowned,unowned(safe),unowned(unsafe),static,class,borrowing,consuming,mutating,nonmutating,prefix,infix,postfix,async # modifierOrder
+
+# We recommend a max width of 100 but _strictly enforce_ a max width of 130
+--max-width 130 # wrap
+
+# rules
+--rules anyObjectProtocol
+--rules blankLinesBetweenScopes
+--rules consecutiveSpaces
+--rules consecutiveBlankLines
+--rules duplicateImports
+--rules extensionAccessControl
+--rules environmentEntry
+--rules hoistPatternLet
+--rules indent
+--rules markTypes
+--rules organizeDeclarations
+--rules redundantParens
+--rules redundantReturn
+--rules redundantSelf
+--rules redundantType
+--rules redundantPattern
+--rules redundantGet
+--rules redundantFileprivate
+--rules redundantRawValues
+--rules redundantEquatable
+--rules sortImports
+--rules sortDeclarations
+--rules strongifiedSelf
+--rules trailingCommas
+--rules trailingSpace
+--rules linebreakAtEndOfFile
+--rules typeSugar
+--rules wrap
+--rules wrapMultilineStatementBraces
+--rules wrapArguments
+--rules wrapAttributes
+--rules wrapEnumCases
+--rules singlePropertyPerLine
+--rules braces
+--rules redundantClosure
+--rules redundantInit
+--rules redundantVoidReturnType
+--rules redundantOptionalBinding
+--rules redundantInternal
+--rules redundantPublic
+--rules redundantProperty
+--rules unusedArguments
+--rules spaceInsideBrackets
+--rules spaceInsideBraces
+--rules spaceAroundBraces
+--rules spaceInsideParens
+--rules spaceAroundParens
+--rules spaceAroundOperators
+--rules enumNamespaces
+--rules blockComments
+--rules docComments
+--rules docCommentsBeforeModifiers
+--rules spaceAroundComments
+--rules spaceInsideComments
+--rules blankLinesAtStartOfScope
+--rules blankLinesAtEndOfScope
+--rules emptyBraces
+--rules andOperator
+--rules opaqueGenericParameters
+--rules genericExtensions
+--rules trailingClosures
+--rules elseOnSameLine
+--rules sortTypealiases
+--rules preferForLoop
+--rules conditionalAssignment
+--rules wrapMultilineConditionalAssignment
+--rules void
+--rules blankLineAfterSwitchCase
+--rules consistentSwitchCaseSpacing
+--rules semicolons
+--rules propertyTypes
+--rules blankLinesBetweenChainedFunctions
+--rules emptyExtensions
+--rules preferCountWhere
+--rules swiftTestingTestCaseNames
+--rules modifiersOnSameLine
+--rules noForceTryInTests
+--rules noForceUnwrapInTests
+--rules redundantThrows
+--rules redundantAsync
+--rules noGuardInTests
+--rules redundantMemberwiseInit
+--rules redundantBreak
+--rules redundantTypedThrows
+--rules preferFinalClasses

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,51 @@
+only_rules:
+  - fatal_error_message
+  - implicitly_unwrapped_optional
+  - legacy_cggeometry_functions
+  - legacy_constant
+  - legacy_constructor
+  - legacy_nsgeometry_functions
+  - unused_optional_binding
+  - unowned_variable_capture
+  - custom_rules
+
+excluded:
+  - .build
+
+indentation: 2
+
+custom_rules:
+  no_objcMembers:
+    name: "@objcMembers"
+    regex: "@objcMembers"
+    message: "Explicitly use @objc on each member you want to expose to Objective-C"
+    severity: error
+  no_direct_standard_out_logs:
+    name: "Writing log messages directly to standard out is disallowed"
+    regex: "(\\bprint|\\bdebugPrint|\\bdump|Swift\\.print|Swift\\.debugPrint|Swift\\.dump|_printChanges)\\s*\\("
+    match_kinds:
+    - identifier
+    message: "Don't commit `print(…)`, `debugPrint(…)`, `dump(…)`, or `_printChanges()` as they write to standard out in release. Either log to a dedicated logging system or silence this warning in debug-only scenarios explicitly using `// swiftlint:disable:next no_direct_standard_out_logs`"
+    severity: error
+  no_file_literal:
+    name: "#file is disallowed"
+    regex: "(\\b#file\\b)"
+    match_kinds:
+    - identifier
+    message: "Instead of #file, use #fileID"
+    severity: error
+  no_filepath_literal:
+    name: "#filePath is disallowed"
+    regex: "(\\b#filePath\\b)"
+    match_kinds:
+    - identifier
+    message: "Instead of #filePath, use #fileID."
+    severity: error
+  no_unchecked_sendable:
+    name: "`@unchecked Sendable` is discouraged."
+    regex: "@unchecked Sendable"
+    match_kinds:
+    - attribute.builtin
+    - typeidentifier
+    message: "Instead of using `@unchecked Sendable`, consider a safe alternative like a standard `Sendable` conformance or using `@preconcurrency import`. If you really must use `@unchecked Sendable`, you can add a `// swiftlint:disable:next no_unchecked_sendable` annotation with an explanation for how we know the type is thread-safe, and why we have to use @unchecked Sendable instead of Sendable. More explanation and suggested safe alternatives are available at https://github.com/airbnb/swift#unchecked-sendable."
+    severity: error

--- a/Package.resolved
+++ b/Package.resolved
@@ -12,16 +12,16 @@
     {
       "identity" : "swift-docc-plugin",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-plugin",
+      "location" : "https://github.com/swiftlang/swift-docc-plugin",
       "state" : {
-        "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
-        "version" : "1.3.0"
+        "revision" : "3e4f133a77e644a5812911a0513aeb7288b07d06",
+        "version" : "1.4.5"
       }
     },
     {
       "identity" : "swift-docc-symbolkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
       "state" : {
         "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nalexn/ViewInspector",
       "state" : {
-        "revision" : "07c090d73e0169c342a4ed46e9010be2781eca1e",
-        "version" : "0.9.8"
+        "revision" : "e9a06346499a3a889165647e3f23f8a7b2609a1c",
+        "version" : "0.10.3"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -30,5 +30,13 @@ let package = Package(
       resources: [
         .process("Resources"),
       ]),
-  ]
+  ],
+  swiftLanguageVersions: [.v5]
 )
+
+for target in package.targets {
+  target.swiftSettings = target.swiftSettings ?? []
+  target.swiftSettings?.append(contentsOf: [
+    .enableExperimentalFeature("StrictConcurrency")
+  ])
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,4 @@
-// swift-tools-version: 5.8
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+// swift-tools-version: 5.9
 
 import PackageDescription
 
@@ -13,9 +12,9 @@ let package = Package(
     .library(name: "RemoteImage", targets: ["RemoteImage"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-    .package(url: "https://github.com/nalexn/ViewInspector", .upToNextMajor(from: "0.9.7")),
-    .package(url: "https://github.com/bdbergeron/Stubby.git", .upToNextMajor(from: "1.0.0")),
+    .package(url: "https://github.com/bdbergeron/Stubby", .upToNextMajor(from: "1.0.0")),
+    .package(url: "https://github.com/nalexn/ViewInspector", .upToNextMajor(from: "0.10.0")),
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.0"),
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     .iOS(.v16),
   ],
   products: [
-    .library(name: "RemoteImage", targets: ["RemoteImage"]),
+    .library(name: "RemoteImage", targets: ["RemoteImage"])
   ],
   dependencies: [
     .package(url: "https://github.com/bdbergeron/Stubby", .upToNextMajor(from: "1.0.0")),
@@ -19,7 +19,8 @@ let package = Package(
   targets: [
     .target(
       name: "RemoteImage",
-      dependencies: []),
+      dependencies: []
+    ),
     .testTarget(
       name: "RemoteImageTests",
       dependencies: [
@@ -28,8 +29,9 @@ let package = Package(
         .product(name: "Stubby", package: "Stubby"),
       ],
       resources: [
-        .process("Resources"),
-      ]),
+        .process("Resources")
+      ]
+    ),
   ],
   swiftLanguageVersions: [.v5]
 )

--- a/RemoteImageDemo/DemosList.swift
+++ b/RemoteImageDemo/DemosList.swift
@@ -21,8 +21,8 @@ struct DemosList: View {
     /// A `RemoteImage` view with a custom placeholder.
     case customPlaceholder = "Custom placeholder"
 
-    /// A `RemoteImage` view with custom content.
-    case customContent = "Custom content"
+    /// A `RemoteImage` view with custom failure.
+    case customFailure = "Custom failure"
 
     /// Image loaded with a custom `URLSession` and using a custom phase transition animation.
     case customURLSession = "Custom URLSession"
@@ -63,11 +63,13 @@ struct DemosList: View {
   private func content(for variant: Variant) -> some View {
     switch variant {
     case .simple:
-      RemoteImage(url: .cuteDoggo)
+      RemoteImage(url: .cuteDoggo) {
+        $0.resizable().scaledToFit()
+      }
 
     case .simpleWithModifier:
       RemoteImage(url: .cuteDoggo) {
-        $0.resizable().scaledToFit()
+        $0.resizable().saturation(0.1).scaledToFit()
       }
 
     case .customPlaceholder:
@@ -75,10 +77,9 @@ struct DemosList: View {
         url: .cuteDoggo,
         configuration: .init(
           skipCache: true,
-          transaction: .init(
-            animation: .spring(duration: 1.0).delay(0.5))))
-      { image in
-        image.resizable().scaledToFit()
+          animation: .spring(duration: 1.0).delay(0.5)))
+      {
+        $0.resizable().scaledToFit()
       } placeholder: {
         ZStack {
           Color.black.opacity(0.05)
@@ -87,12 +88,11 @@ struct DemosList: View {
         .aspectRatio(1, contentMode: .fit)
       }
 
-    case .customContent:
+    case .customFailure:
       RemoteImage(
         url: .githubRepo,
-        configuration: RemoteImageConfiguration(
-          transaction: Transaction(
-            animation: .spring(duration: 1.0).delay(0.5))))
+        configuration: .init(
+          animation: .spring(duration: 1.0).delay(0.5)))
       {
         $0.resizable().scaledToFit()
       } placeholder: {
@@ -120,10 +120,10 @@ struct DemosList: View {
     case .customURLSession:
       RemoteImage(
         url: .cuteDoggo,
-        urlSession: URLSession(configuration: .ephemeral),
-        configuration: RemoteImageConfiguration(
-          transaction: Transaction(
-            animation: .spring(duration: 1.0).delay(0.5))))
+        urlSession: .init(
+          configuration: .ephemeral),
+        configuration: .init(
+          animation: .spring(duration: 1.0).delay(0.5)))
       {
         $0.resizable().scaledToFit()
       }
@@ -132,9 +132,8 @@ struct DemosList: View {
       RemoteImage(
         url: .cuteDoggo,
         cache: .inMemoryOnly,
-        configuration: RemoteImageConfiguration(
-          transaction: Transaction(
-            animation: .spring(duration: 1.0).delay(0.5))))
+        configuration: .init(
+          animation: .spring(duration: 1.0).delay(0.5)))
       {
         $0.resizable().scaledToFit()
       } placeholder: {

--- a/RemoteImageDemo/DemosList.swift
+++ b/RemoteImageDemo/DemosList.swift
@@ -9,8 +9,6 @@ struct DemosList: View {
 
   // MARK: Internal
 
-  @State var selectedVariant: Variant?
-
   enum Variant: String, CaseIterable {
     /// A simple `RemoteImage` view.
     case simple = "Simple"
@@ -32,6 +30,8 @@ struct DemosList: View {
     /// and the provided cache instance.
     case customCache = "Custom Cache"
   }
+
+  @State var selectedVariant: Variant?
 
   var body: some View {
     NavigationStack {
@@ -77,8 +77,9 @@ struct DemosList: View {
         url: .cuteDoggo,
         configuration: .init(
           skipCache: true,
-          animation: .spring(duration: 1.0).delay(0.5)))
-      {
+          animation: .spring(duration: 1.0).delay(0.5)
+        )
+      ) {
         $0.resizable().scaledToFit()
       } placeholder: {
         ZStack {
@@ -92,8 +93,8 @@ struct DemosList: View {
       RemoteImage(
         url: .githubRepo,
         configuration: .init(
-          animation: .spring(duration: 1.0).delay(0.5)))
-      {
+          animation: .spring(duration: 1.0).delay(0.5))
+      ) {
         $0.resizable().scaledToFit()
       } placeholder: {
         ZStack {
@@ -123,8 +124,8 @@ struct DemosList: View {
         urlSession: .init(
           configuration: .ephemeral),
         configuration: .init(
-          animation: .spring(duration: 1.0).delay(0.5)))
-      {
+          animation: .spring(duration: 1.0).delay(0.5))
+      ) {
         $0.resizable().scaledToFit()
       }
 
@@ -133,8 +134,8 @@ struct DemosList: View {
         url: .cuteDoggo,
         cache: .inMemoryOnly,
         configuration: .init(
-          animation: .spring(duration: 1.0).delay(0.5)))
-      {
+          animation: .spring(duration: 1.0).delay(0.5))
+      ) {
         $0.resizable().scaledToFit()
       } placeholder: {
         ZStack {
@@ -148,7 +149,8 @@ struct DemosList: View {
 }
 
 extension URL {
-  fileprivate static let cuteDoggo = URL(string: "https://fastly.picsum.photos/id/237/1000/1000.jpg?hmac=5nME13-xBzl4yi2t1tFev6zsf5IWO2-efZAoXEm9ltc")!
+  fileprivate static let cuteDoggo =
+    URL(string: "https://fastly.picsum.photos/id/237/1000/1000.jpg?hmac=5nME13-xBzl4yi2t1tFev6zsf5IWO2-efZAoXEm9ltc")!
 
   fileprivate static let githubRepo = URL(string: "https://github.com/bdbergeron/RemoteImage")!
 }

--- a/Sources/RemoteImage/Extensions/Image+PlatformNativeImage.swift
+++ b/Sources/RemoteImage/Extensions/Image+PlatformNativeImage.swift
@@ -10,11 +10,11 @@ typealias PlatformNativeImage = NSImage
 
 extension Image {
   init(nativeImage: PlatformNativeImage) {
-#if os(iOS)
+    #if os(iOS)
     self.init(uiImage: nativeImage)
-#elseif os(macOS)
+    #elseif os(macOS)
     self.init(nsImage: nativeImage)
-#endif
+    #endif
   }
 }
 

--- a/Sources/RemoteImage/Extensions/URLSession+CachedData.swift
+++ b/Sources/RemoteImage/Extensions/URLSession+CachedData.swift
@@ -10,7 +10,7 @@ extension URLSession {
   /// - Parameter skipCache: Whether or not to skip loading data from the local cache.
   /// - Returns: A tuple that contains the `Data` from the response, along with the `URLResponse` itself
   /// and whether or not the response was served from the underlying `URLCache`.
-  func cachedData(
+  func data(
     from url: URL,
     skipCache: Bool)
     async throws

--- a/Sources/RemoteImage/Extensions/URLSession+CachedData.swift
+++ b/Sources/RemoteImage/Extensions/URLSession+CachedData.swift
@@ -13,13 +13,12 @@ extension URLSession {
   /// and whether or not the response was served from the underlying `URLCache`.
   func data(
     from url: URL,
-    skipCache: Bool)
-    async throws
-    -> (data: Data, urlResponse: URLResponse, didLoadFromCache: Bool)
-  {
+    skipCache: Bool
+  ) async throws -> (data: Data, urlResponse: URLResponse, didLoadFromCache: Bool) {
     let request = URLRequest(
       url: url,
-      cachePolicy: skipCache ? .reloadIgnoringLocalCacheData : .useProtocolCachePolicy)
+      cachePolicy: skipCache ? .reloadIgnoringLocalCacheData : .useProtocolCachePolicy
+    )
     let cacheListener = CacheListener()
     let (data, urlResponse) = try await data(for: request, delegate: cacheListener)
     let didLoadFromCache = cacheListener.didLoadFromCache.withLock { $0 }
@@ -36,8 +35,8 @@ private final class CacheListener: NSObject, URLSessionTaskDelegate {
   nonisolated func urlSession(
     _: URLSession,
     task _: URLSessionTask,
-    didFinishCollecting metrics: URLSessionTaskMetrics)
-  {
+    didFinishCollecting metrics: URLSessionTaskMetrics
+  ) {
     let resourceFetchType = metrics.transactionMetrics.last?.resourceFetchType
     didLoadFromCache.withLock { $0 = resourceFetchType == .localCache }
   }

--- a/Sources/RemoteImage/RemoteImage+Helpers.swift
+++ b/Sources/RemoteImage/RemoteImage+Helpers.swift
@@ -9,8 +9,7 @@ extension RemoteImage {
   ///   Otherwise, and empty image will be used.
   @ViewBuilder
   static func imageOrEmpty(
-    _ phase: RemoteImagePhase)
-    -> Content
+    _ phase: RemoteImagePhase) -> Content
     where
     Content == _ConditionalContent<Image, Image>
   {
@@ -32,8 +31,8 @@ extension RemoteImage {
   static func contentForPhase<I, P>(
     _ phase: RemoteImagePhase,
     @ViewBuilder content: @escaping (Image) -> I,
-    @ViewBuilder placeholder: @escaping () -> P)
-    -> Content
+    @ViewBuilder placeholder: @escaping () -> P
+  ) -> Content
     where
     Content == _ConditionalContent<I, P>,
     I: View,
@@ -59,8 +58,8 @@ extension RemoteImage {
     _ phase: RemoteImagePhase,
     @ViewBuilder content: @escaping (Image) -> I,
     @ViewBuilder placeholder: @escaping () -> P,
-    @ViewBuilder failure: @escaping (Error) -> F)
-    -> Content
+    @ViewBuilder failure: @escaping (Error) -> F
+  ) -> Content
     where
     Content == _ConditionalContent<_ConditionalContent<P, I>, F>,
     I: View,

--- a/Sources/RemoteImage/RemoteImage+InitWithCache.swift
+++ b/Sources/RemoteImage/RemoteImage+InitWithCache.swift
@@ -18,14 +18,16 @@ extension RemoteImage {
     url: URL?,
     cache: URLCache,
     configuration: RemoteImageConfiguration = .init(),
-    @ViewBuilder content: @escaping (RemoteImagePhase) -> Content)
-  {
+    @ViewBuilder content: @escaping (RemoteImagePhase) -> Content
+  ) {
     self.init(
       model: RemoteImageViewModel(
         url: url,
         cache: cache,
-        configuration: configuration),
-      content: content)
+        configuration: configuration
+      ),
+      content: content
+    )
   }
 
   /// Initialize a new `RemoteImage` instance using either the fetched remote image or an empty fallback.
@@ -38,7 +40,8 @@ extension RemoteImage {
   public init(
     url: URL?,
     cache: URLCache,
-    configuration: RemoteImageConfiguration = .init())
+    configuration: RemoteImageConfiguration = .init()
+  )
     where
     Content == _ConditionalContent<Image, Image>
   {
@@ -46,7 +49,8 @@ extension RemoteImage {
       url: url,
       cache: cache,
       configuration: configuration,
-      content: Self.imageOrEmpty)
+      content: Self.imageOrEmpty
+    )
   }
 
   /// Initialize a new `RemoteImage` instance, using either the fetched remote image or an empty fallback, and calling the provided `content` closure
@@ -62,21 +66,23 @@ extension RemoteImage {
     url: URL?,
     cache: URLCache,
     configuration: RemoteImageConfiguration = .init(),
-    @ViewBuilder content: @escaping (Image) -> I)
+    @ViewBuilder content: @escaping (Image) -> I
+  )
     where
     Content == _ConditionalContent<I, Image>
   {
     self.init(
       url: url,
       cache: cache,
-      configuration: configuration)
-    { phase in
+      configuration: configuration
+    ) { phase in
       Self.contentForPhase(
         phase,
         content: content,
         placeholder: {
           Image(nativeImage: .init())
-        })
+        }
+      )
     }
   }
 
@@ -95,7 +101,8 @@ extension RemoteImage {
     cache: URLCache,
     configuration: RemoteImageConfiguration = .init(),
     @ViewBuilder content: @escaping (Image) -> I,
-    @ViewBuilder placeholder: @escaping () -> P)
+    @ViewBuilder placeholder: @escaping () -> P
+  )
     where
     Content == _ConditionalContent<I, P>,
     I: View,
@@ -104,15 +111,16 @@ extension RemoteImage {
     self.init(
       url: url,
       cache: cache,
-      configuration: configuration)
-    { phase in
+      configuration: configuration
+    ) { phase in
       Self.contentForPhase(
         phase,
         content: content,
-        placeholder: placeholder)
+        placeholder: placeholder
+      )
     }
   }
-  
+
   /// Initialize a new `RemoteImage` instance, calling the provided `content` closure to optionally modify the loaded image.
   /// While the image loads, the `placeholder` is shown. If the image fails to load, `failure` is shown.
   ///
@@ -131,7 +139,8 @@ extension RemoteImage {
     configuration: RemoteImageConfiguration = .init(),
     @ViewBuilder content: @escaping (Image) -> I,
     @ViewBuilder placeholder: @escaping () -> P,
-    @ViewBuilder failure: @escaping (Error) -> F)
+    @ViewBuilder failure: @escaping (Error) -> F
+  )
     where
     Content == _ConditionalContent<_ConditionalContent<P, I>, F>,
     I: View,
@@ -141,13 +150,14 @@ extension RemoteImage {
     self.init(
       url: url,
       cache: cache,
-      configuration: configuration)
-    { phase in
+      configuration: configuration
+    ) { phase in
       Self.contentForPhase(
         phase,
         content: content,
         placeholder: placeholder,
-        failure: failure)
+        failure: failure
+      )
     }
   }
 }

--- a/Sources/RemoteImage/RemoteImage.swift
+++ b/Sources/RemoteImage/RemoteImage.swift
@@ -15,22 +15,22 @@ public struct RemoteImageConfiguration {
   ///   - skipCache: Whether or not to bypass the cache. Default is `false`.
   ///   - scale: The scale to use for the image. The default is `1`. Set a different value when loading images designed for higher resolution displays.
   ///     For example, set a value of `2` for an image that you would name with the `@2x` suffix if stored in a file on disk.
-  ///   - transaction: The transaction to use when the phase changes. Default is an empty `Transaction`.
-  ///   - disableTransactionWithCachedResponse: Whether or not to disable the ``transaction`` when a cached image is returned.
+  ///   - animation: The animation to use when the phase changes. Uses ``Animation/default`` if not specified.
+  ///   - disableAnimationWithCachedResponse: Whether or not to disable the ``animation`` when a cached image is returned.
   ///     Defaults to `true`.
   ///   - logger: An optional `Logger` instance that will be used internally. Defaults to one that utilizes the "io.github.bdbergeron.RemoteImage" subsystem
   ///     and "RemoteImage" category.
   public init(
     skipCache: Bool = false,
     scale: CGFloat = 1.0,
-    transaction: Transaction = .init(),
-    disableTransactionWithCachedResponse: Bool = true,
+    animation: Animation = .default,
+    disableAnimationWithCachedResponse: Bool = true,
     logger: Logger? = .init(subsystem: "io.github.bdbergeron.RemoteImage", category: "RemoteImage"))
   {
     self.skipCache = skipCache
     self.scale = scale
-    self.transaction = transaction
-    self.disableTransactionWithCachedResponse = disableTransactionWithCachedResponse
+    self.animation = animation
+    self.disableAnimationWithCachedResponse = disableAnimationWithCachedResponse
     self.logger = logger
   }
 
@@ -38,8 +38,8 @@ public struct RemoteImageConfiguration {
 
   let skipCache: Bool
   let scale: CGFloat
-  let transaction: Transaction
-  let disableTransactionWithCachedResponse: Bool
+  let animation: Animation
+  let disableAnimationWithCachedResponse: Bool
   let logger: Logger?
 
 }
@@ -328,7 +328,7 @@ struct RemoteImage_Previews: PreviewProvider {
         urlSession: urlSession,
         configuration: .init(
           skipCache: skipCache,
-          transaction: .init(animation: .easeIn.delay(0.5))))
+          animation: .easeIn.delay(0.5)))
       { phase in
         switch phase {
         case .loaded(let image):

--- a/Sources/RemoteImage/RemoteImage.swift
+++ b/Sources/RemoteImage/RemoteImage.swift
@@ -25,8 +25,8 @@ public struct RemoteImageConfiguration {
     scale: CGFloat = 1.0,
     animation: Animation = .default,
     disableAnimationWithCachedResponse: Bool = true,
-    logger: Logger? = .init(subsystem: "io.github.bdbergeron.RemoteImage", category: "RemoteImage"))
-  {
+    logger: Logger? = .init(subsystem: "io.github.bdbergeron.RemoteImage", category: "RemoteImage")
+  ) {
     self.skipCache = skipCache
     self.scale = scale
     self.animation = animation
@@ -62,9 +62,9 @@ public enum RemoteImagePhase {
   var image: Image? {
     switch self {
     case .loaded(let image):
-      return image
+      image
     case .placeholder, .failure:
-      return nil
+      nil
     }
   }
 }
@@ -86,14 +86,16 @@ public struct RemoteImage<Content: View>: View {
     url: URL?,
     urlSession: URLSession = .shared,
     configuration: RemoteImageConfiguration = .init(),
-    @ViewBuilder content: @escaping (RemoteImagePhase) -> Content)
-  {
+    @ViewBuilder content: @escaping (RemoteImagePhase) -> Content
+  ) {
     self.init(
       model: RemoteImageViewModel(
         url: url,
         urlSession: urlSession,
-        configuration: configuration),
-      content: content)
+        configuration: configuration
+      ),
+      content: content
+    )
   }
 
   /// Initialize a new `RemoteImage` instance using either the fetched remote image or an empty fallback.
@@ -104,7 +106,8 @@ public struct RemoteImage<Content: View>: View {
   public init(
     url: URL?,
     urlSession: URLSession = .shared,
-    configuration: RemoteImageConfiguration = .init())
+    configuration: RemoteImageConfiguration = .init()
+  )
     where
     Content == _ConditionalContent<Image, Image>
   {
@@ -112,7 +115,8 @@ public struct RemoteImage<Content: View>: View {
       url: url,
       urlSession: urlSession,
       configuration: configuration,
-      content: Self.imageOrEmpty)
+      content: Self.imageOrEmpty
+    )
   }
 
   /// Initialize a new `RemoteImage` instance, using either the fetched remote image or an empty fallback, and calling the provided `content` closure
@@ -126,21 +130,23 @@ public struct RemoteImage<Content: View>: View {
     url: URL?,
     urlSession: URLSession = .shared,
     configuration: RemoteImageConfiguration = .init(),
-    @ViewBuilder content: @escaping (Image) -> I)
+    @ViewBuilder content: @escaping (Image) -> I
+  )
     where
     Content == _ConditionalContent<I, Image>
   {
     self.init(
       url: url,
       urlSession: urlSession,
-      configuration: configuration)
-    { phase in
+      configuration: configuration
+    ) { phase in
       Self.contentForPhase(
         phase,
         content: content,
         placeholder: {
           Image(nativeImage: .init())
-        })
+        }
+      )
     }
   }
 
@@ -157,7 +163,8 @@ public struct RemoteImage<Content: View>: View {
     urlSession: URLSession = .shared,
     configuration: RemoteImageConfiguration = .init(),
     @ViewBuilder content: @escaping (Image) -> I,
-    @ViewBuilder placeholder: @escaping () -> P)
+    @ViewBuilder placeholder: @escaping () -> P
+  )
     where
     Content == _ConditionalContent<I, P>,
     I: View,
@@ -166,12 +173,13 @@ public struct RemoteImage<Content: View>: View {
     self.init(
       url: url,
       urlSession: urlSession,
-      configuration: configuration)
-    { phase in
+      configuration: configuration
+    ) { phase in
       Self.contentForPhase(
         phase,
         content: content,
-        placeholder: placeholder)
+        placeholder: placeholder
+      )
     }
   }
 
@@ -192,7 +200,8 @@ public struct RemoteImage<Content: View>: View {
     configuration: RemoteImageConfiguration = .init(),
     @ViewBuilder content: @escaping (Image) -> I,
     @ViewBuilder placeholder: @escaping () -> P,
-    @ViewBuilder failure: @escaping (Error) -> F)
+    @ViewBuilder failure: @escaping (Error) -> F
+  )
     where
     Content == _ConditionalContent<_ConditionalContent<P, I>, F>,
     I: View,
@@ -202,14 +211,23 @@ public struct RemoteImage<Content: View>: View {
     self.init(
       url: url,
       urlSession: urlSession,
-      configuration: configuration)
-    { phase in
+      configuration: configuration
+    ) { phase in
       Self.contentForPhase(
         phase,
         content: content,
         placeholder: placeholder,
-        failure: failure)
+        failure: failure
+      )
     }
+  }
+
+  init(
+    model: RemoteImageViewModel,
+    @ViewBuilder content: @escaping (RemoteImagePhase) -> Content
+  ) {
+    _model = .init(wrappedValue: model)
+    self.content = content
   }
 
   // MARK: Public
@@ -227,14 +245,6 @@ public struct RemoteImage<Content: View>: View {
   }
 
   // MARK: Internal
-
-  init(
-    model: RemoteImageViewModel,
-    @ViewBuilder content: @escaping (RemoteImagePhase) -> Content)
-  {
-    _model = .init(wrappedValue: model)
-    self.content = content
-  }
 
   @StateObject var model: RemoteImageViewModel
 
@@ -262,9 +272,10 @@ struct RemoteImage_Previews: PreviewProvider {
 
     remoteImage(
       url: imageURL,
-      skipCache: true)
-      .previewDisplayName("Skip Cache")
-      .previewLayout(.sizeThatFits)
+      skipCache: true
+    )
+    .previewDisplayName("Skip Cache")
+    .previewLayout(.sizeThatFits)
 
     remoteImage(
       url: .init(string: "https://www.example.com"))
@@ -278,9 +289,10 @@ struct RemoteImage_Previews: PreviewProvider {
         ZStack {
           EmptyView()
         }
-      })
-      .previewDisplayName("Empty Placeholder")
-      .previewLayout(.sizeThatFits)
+      }
+    )
+    .previewDisplayName("Empty Placeholder")
+    .previewLayout(.sizeThatFits)
   }
 
   // MARK: Private
@@ -291,14 +303,13 @@ struct RemoteImage_Previews: PreviewProvider {
   private static func remoteImage(
     url: URL?,
     urlSession: URLSession = .shared,
-    skipCache: Bool = false)
-    -> some View
-  {
+    skipCache: Bool = false
+  ) -> some View {
     remoteImage(
       url: url,
       urlSession: urlSession,
-      skipCache: skipCache) 
-    {
+      skipCache: skipCache
+    ) {
       ZStack {
         Color(white: 0.8)
         ProgressView()
@@ -319,17 +330,17 @@ struct RemoteImage_Previews: PreviewProvider {
     urlSession: URLSession = .shared,
     skipCache: Bool = false,
     @ViewBuilder placeholder: @escaping () -> some View = EmptyView.init,
-    @ViewBuilder failure: @escaping (Error) -> some View = { _ in EmptyView() })
-    -> some View
-  {
+    @ViewBuilder failure: @escaping (Error) -> some View = { _ in EmptyView() }
+  ) -> some View {
     GeometryReader { geometry in
       RemoteImage(
         url: url,
         urlSession: urlSession,
         configuration: .init(
           skipCache: skipCache,
-          animation: .easeIn.delay(0.5)))
-      { phase in
+          animation: .easeIn.delay(0.5)
+        )
+      ) { phase in
         switch phase {
         case .loaded(let image):
           image
@@ -337,8 +348,10 @@ struct RemoteImage_Previews: PreviewProvider {
             .scaledToFill()
             .frame(width: geometry.size.width, height: geometry.size.height)
             .clipped()
+
         case .placeholder:
           placeholder()
+
         case .failure(let error):
           failure(error)
         }

--- a/Sources/RemoteImage/RemoteImageViewModel+InitWithCache.swift
+++ b/Sources/RemoteImage/RemoteImageViewModel+InitWithCache.swift
@@ -15,8 +15,8 @@ extension RemoteImageViewModel {
   convenience init(
     url: URL?,
     cache: URLCache,
-    configuration: RemoteImageConfiguration)
-  {
+    configuration: RemoteImageConfiguration
+  ) {
     self.init(
       url: url,
       urlSession: URLSession(
@@ -25,6 +25,7 @@ extension RemoteImageViewModel {
           configuration.urlCache = cache
           return configuration
         }()),
-      configuration: configuration)
+      configuration: configuration
+    )
   }
 }

--- a/Sources/RemoteImage/RemoteImageViewModel.swift
+++ b/Sources/RemoteImage/RemoteImageViewModel.swift
@@ -20,15 +20,15 @@ final class RemoteImageViewModel: ObservableObject {
   init(
     url: URL?,
     urlSession: URLSession = .shared,
-    configuration: RemoteImageConfiguration = .init())
-  {
+    configuration: RemoteImageConfiguration = .init()
+  ) {
     self.url = url
     self.urlSession = urlSession
-    self.skipCache = configuration.skipCache
-    self.scale = configuration.scale
-    self.animation = configuration.animation
-    self.disableAnimationWithCachedResponse = configuration.disableAnimationWithCachedResponse
-    self.logger = configuration.logger
+    skipCache = configuration.skipCache
+    scale = configuration.scale
+    animation = configuration.animation
+    disableAnimationWithCachedResponse = configuration.disableAnimationWithCachedResponse
+    logger = configuration.logger
   }
 
   // MARK: Internal
@@ -61,7 +61,7 @@ final class RemoteImageViewModel: ObservableObject {
   let logger: Logger?
 
   /// The current image phase.
-  @Published var phase: RemoteImagePhase = .placeholder
+  @Published var phase = RemoteImagePhase.placeholder
 
   var loadingTask: Task<Void, Swift.Error>?
 
@@ -138,7 +138,10 @@ final class RemoteImageViewModel: ObservableObject {
     do {
       let (data, _, didLoadFromCache) = try await urlSession.data(from: url, skipCache: skipCache)
       try Task.checkCancellation()
-      logger?.debug("Image loaded from \(url) with \(data.count) bytes. From cache: \(String(describing: didLoadFromCache), privacy: .public).")
+      logger?
+        .debug(
+          "Image loaded from \(url) with \(data.count) bytes. From cache: \(String(describing: didLoadFromCache), privacy: .public)."
+        )
       let image = try createImage(with: data)
       try Task.checkCancellation()
       let disableAnimation = didLoadFromCache && disableAnimationWithCachedResponse

--- a/Sources/RemoteImage/RemoteImageViewModel.swift
+++ b/Sources/RemoteImage/RemoteImageViewModel.swift
@@ -26,8 +26,8 @@ final class RemoteImageViewModel: ObservableObject {
     self.urlSession = urlSession
     self.skipCache = configuration.skipCache
     self.scale = configuration.scale
-    self.transaction = configuration.transaction
-    self.disableTransactionWithCachedResponse = configuration.disableTransactionWithCachedResponse
+    self.animation = configuration.animation
+    self.disableAnimationWithCachedResponse = configuration.disableAnimationWithCachedResponse
     self.logger = configuration.logger
   }
 
@@ -52,11 +52,11 @@ final class RemoteImageViewModel: ObservableObject {
   let scale: CGFloat
 
   /// The transaction to use when the phase changes.
-  let transaction: Transaction
+  let animation: Animation
 
-  /// Whether or not to disable the ``transaction`` when a cached image is returned.
-  let disableTransactionWithCachedResponse: Bool
-  
+  /// Whether or not to disable the ``animation`` when a cached image is returned.
+  let disableAnimationWithCachedResponse: Bool
+
   /// An optional `Logger` instance that will be used internally.
   let logger: Logger?
 
@@ -141,7 +141,7 @@ final class RemoteImageViewModel: ObservableObject {
       logger?.debug("Image loaded from \(url) with \(data.count) bytes. From cache: \(String(describing: didLoadFromCache), privacy: .public).")
       let image = try createImage(with: data)
       try Task.checkCancellation()
-      let disableAnimation = didLoadFromCache && disableTransactionWithCachedResponse
+      let disableAnimation = didLoadFromCache && disableAnimationWithCachedResponse
       logger?.debug("Setting phase to .loaded for \(url). Animated: \(String(describing: !disableAnimation), privacy: .public).")
       setPhase(.loaded(image), animated: !disableAnimation)
     } catch URLError.cancelled {
@@ -163,7 +163,7 @@ final class RemoteImageViewModel: ObservableObject {
       self.phase = phase
       return
     }
-    withAnimation(transaction.animation) {
+    withAnimation(animation) {
       self.phase = phase
     }
   }

--- a/Sources/RemoteImage/RemoteImageViewModel.swift
+++ b/Sources/RemoteImage/RemoteImageViewModel.swift
@@ -136,7 +136,7 @@ final class RemoteImageViewModel: ObservableObject {
     // Perform network fetch.
     logger?.debug("Loading image from \(url, privacy: .public)...")
     do {
-      let (data, _, didLoadFromCache) = try await urlSession.cachedData(from: url, skipCache: skipCache)
+      let (data, _, didLoadFromCache) = try await urlSession.data(from: url, skipCache: skipCache)
       try Task.checkCancellation()
       logger?.debug("Image loaded from \(url) with \(data.count) bytes. From cache: \(String(describing: didLoadFromCache), privacy: .public).")
       let image = try createImage(with: data)

--- a/Tests/RemoteImageTests/Helpers/Helpers.swift
+++ b/Tests/RemoteImageTests/Helpers/Helpers.swift
@@ -15,7 +15,7 @@ extension Data {
   }
 }
 
-extension URL: ExpressibleByStringLiteral {
+extension URL: @retroactive ExpressibleByStringLiteral {
 
   // MARK: Lifecycle
 

--- a/Tests/RemoteImageTests/Helpers/Helpers.swift
+++ b/Tests/RemoteImageTests/Helpers/Helpers.swift
@@ -15,6 +15,8 @@ extension Data {
   }
 }
 
+// MARK: - URL + @retroactive ExpressibleByStringLiteral
+
 extension URL: @retroactive ExpressibleByStringLiteral {
 
   // MARK: Lifecycle
@@ -44,7 +46,7 @@ extension URLSession {
   ///   - url: Image URL to fetch.
   ///   - cache: Cache instance to use with URLSession.
   /// - Returns: An ``Image`` instance of the fetched image.
-  @discardableResult 
+  @discardableResult
   func fetchImage(from url: URL) async throws -> Image {
     let (data, _) = try await data(from: url)
     XCTAssertFalse(data.isEmpty)
@@ -57,7 +59,7 @@ extension Image {
   /// Get the data representation of this `Image` instance.
   /// - Parameter scale: Display scale to render the image at.
   /// - Returns: A `Data` representation of this `Image` view.
-  @MainActor 
+  @MainActor
   func dataRepresentation(scale: CGFloat = 1.0) -> Data? {
     let renderer = ImageRenderer(content: self)
     renderer.scale = scale

--- a/Tests/RemoteImageTests/Helpers/RemoteImageStubbedURL.swift
+++ b/Tests/RemoteImageTests/Helpers/RemoteImageStubbedURL.swift
@@ -16,21 +16,27 @@ enum RemoteImageStubbedURL: CaseIterable {
 // MARK: RawRepresentable
 
 extension RemoteImageStubbedURL: RawRepresentable {
+
+  // MARK: Lifecycle
+
   init?(rawValue: URL) {
     guard let stubbedURL = Self.allCases.first(where: { $0.rawValue == rawValue }) else { return nil }
     self = stubbedURL
   }
 
+  // MARK: Internal
+
+  static let allURLs = allCases.map(\.rawValue)
+
   var rawValue: URL {
     switch self {
     case .cuteDoggoPicture:
-      return .cuteDoggoPicture
+      .cuteDoggoPicture
     case .invalidImage:
-      return .invalidImage
+      .invalidImage
     }
   }
 
-  static let allURLs = allCases.map(\.rawValue)
 }
 
 // MARK: StubbyResponseProvider
@@ -60,17 +66,19 @@ extension RemoteImageStubbedURL: StubbyResponseProvider {
     get throws {
       switch self {
       case .cuteDoggoPicture:
-        return try .success(
+        try .success(
           .init(
             data: try XCTUnwrap(.cuteDoggo),
             for: rawValue,
-            cacheStoragePolicy: .allowedInMemoryOnly))
+            cacheStoragePolicy: .allowedInMemoryOnly
+          ))
 
       case .invalidImage:
-        return try .success(
+        try .success(
           .init(
             data: try XCTUnwrap("Hello, world!".data(using: .utf8)),
-            for: rawValue))
+            for: rawValue
+          ))
       }
     }
   }

--- a/Tests/RemoteImageTests/RemoteImageTests.swift
+++ b/Tests/RemoteImageTests/RemoteImageTests.swift
@@ -19,7 +19,7 @@ final class RemoteImageTests: XCTestCase {
     urlSession = createURLSession()
   }
 
-  func test_initWithURLSession_createsViewModelWithDefaults() throws {
+  func test_initWithURLSession_createsViewModelWithDefaults() {
     var view = RemoteImage(url: .cuteDoggoPicture)
 
     let expectation = view.on(\.didAppear) { inspectable in
@@ -31,7 +31,7 @@ final class RemoteImageTests: XCTestCase {
     wait(for: [expectation])
   }
 
-  func test_initWithURLSession_usesEmptyPlaceholderImage() throws {
+  func test_initWithURLSession_usesEmptyPlaceholderImage() {
     var view = RemoteImage(url: .cuteDoggoPicture, urlSession: urlSession)
 
     let expectation = view.on(\.didAppear) { inspectable in
@@ -77,7 +77,7 @@ final class RemoteImageTests: XCTestCase {
     await fulfillment(of: [expectation])
   }
 
-  func test_initWithURLSession_contentAndPlaceholder_showsPlaceholder() throws {
+  func test_initWithURLSession_contentAndPlaceholder_showsPlaceholder() {
     var view = RemoteImage(url: .cuteDoggoPicture, urlSession: urlSession) { image in
       image
     } placeholder: {
@@ -111,7 +111,7 @@ final class RemoteImageTests: XCTestCase {
     await fulfillment(of: [expectation])
   }
 
-  func test_initWithURLSession_contentPlaceholderFailure_showsPlaceholder() throws {
+  func test_initWithURLSession_contentPlaceholderFailure_showsPlaceholder() {
     var view = RemoteImage(url: .cuteDoggoPicture, urlSession: urlSession) { image in
       image
     } placeholder: {
@@ -171,7 +171,7 @@ final class RemoteImageTests: XCTestCase {
     await fulfillment(of: [expectation])
   }
 
-  func test_initWithCache_usesEmptyPlaceholderImage() throws {
+  func test_initWithCache_usesEmptyPlaceholderImage() {
     let cache = URLCache(memoryCapacity: 1_000_000, diskCapacity: 0)
     var view = RemoteImage(url: .cuteDoggoPicture, cache: cache)
 
@@ -228,7 +228,7 @@ final class RemoteImageTests: XCTestCase {
     await fulfillment(of: [expectation])
   }
 
-  func test_initWithCache_contentAndPlaceholder_showsPlaceholder() throws {
+  func test_initWithCache_contentAndPlaceholder_showsPlaceholder() {
     let cache = URLCache(memoryCapacity: 1_000_000, diskCapacity: 0)
 
     var view = RemoteImage(url: .cuteDoggoPicture, cache: cache) { image in
@@ -269,7 +269,7 @@ final class RemoteImageTests: XCTestCase {
     await fulfillment(of: [expectation])
   }
 
-  func test_initWithCache_contentPlaceholderFailure_showsPlaceholder() throws {
+  func test_initWithCache_contentPlaceholderFailure_showsPlaceholder() {
     let cache = URLCache(memoryCapacity: 1_000_000, diskCapacity: 0)
 
     var view = RemoteImage(url: .cuteDoggoPicture, cache: cache) { image in
@@ -348,7 +348,8 @@ final class RemoteImageTests: XCTestCase {
   private func createURLSession(configuration: URLSessionConfiguration = .ephemeral) -> URLSession {
     .stubbed(
       responseProvider: RemoteImageStubbedURL.self,
-      configuration: configuration)
+      configuration: configuration
+    )
   }
 
 }

--- a/Tests/RemoteImageTests/RemoteImageTests.swift
+++ b/Tests/RemoteImageTests/RemoteImageTests.swift
@@ -15,7 +15,7 @@ final class RemoteImageTests: XCTestCase {
 
   // MARK: Internal
 
-  override func setUp() {
+  override func setUp() async throws {
     urlSession = createURLSession()
   }
 

--- a/Tests/RemoteImageTests/RemoteImageTests.swift
+++ b/Tests/RemoteImageTests/RemoteImageTests.swift
@@ -343,7 +343,7 @@ final class RemoteImageTests: XCTestCase {
 
   // MARK: Private
 
-  private var urlSession: URLSession!
+  private var urlSession: URLSession! // swiftlint:disable:this implicitly_unwrapped_optional
 
   private func createURLSession(configuration: URLSessionConfiguration = .ephemeral) -> URLSession {
     .stubbed(

--- a/Tests/RemoteImageTests/RemoteImageViewModelTests.swift
+++ b/Tests/RemoteImageTests/RemoteImageViewModelTests.swift
@@ -14,7 +14,7 @@ final class RemoteImageViewModelTests: XCTestCase {
 
   // MARK: Internal
 
-  override func setUp() {
+  override func setUp() async throws {
     urlSession = .stubbed(responseProvider: RemoteImageStubbedURL.self)
   }
 

--- a/Tests/RemoteImageTests/RemoteImageViewModelTests.swift
+++ b/Tests/RemoteImageTests/RemoteImageViewModelTests.swift
@@ -211,7 +211,7 @@ final class RemoteImageViewModelTests: XCTestCase {
 
   // MARK: Private
 
-  private var urlSession: URLSession!
+  private var urlSession: URLSession! // swiftlint:disable:this implicitly_unwrapped_optional
 
 }
 

--- a/Tests/RemoteImageTests/RemoteImageViewModelTests.swift
+++ b/Tests/RemoteImageTests/RemoteImageViewModelTests.swift
@@ -30,10 +30,11 @@ final class RemoteImageViewModelTests: XCTestCase {
 
   func test_cachedImage_returnsNilIfSkipCache() {
     let model = RemoteImageViewModel(
-      url: nil, 
+      url: nil,
       urlSession: urlSession,
       configuration: .init(
-        skipCache: true))
+        skipCache: true)
+    )
     XCTAssertNil(model.cachedImage)
   }
 
@@ -73,7 +74,7 @@ final class RemoteImageViewModelTests: XCTestCase {
       XCTFail("Phase should be `.loaded`.")
       return
     }
-    
+
     model.onAppear()
     XCTAssertNil(model.loadingTask)
     guard case .loaded = model.phase else {
@@ -88,7 +89,7 @@ final class RemoteImageViewModelTests: XCTestCase {
       XCTFail("Initial phase should be `.placeholder`.")
       return
     }
-    
+
     model.onAppear()
     let task = try XCTUnwrap(model.loadingTask)
     try await task.value
@@ -126,7 +127,7 @@ final class RemoteImageViewModelTests: XCTestCase {
       XCTFail("Initial phase should be `.placeholder`.")
       return
     }
-    
+
     model.onAppear()
     let task = try XCTUnwrap(model.loadingTask)
     try await task.value
@@ -145,7 +146,7 @@ final class RemoteImageViewModelTests: XCTestCase {
     }
 
     try await urlSession.fetchImage(from: .cuteDoggoPicture)
-    
+
     model.onAppear()
     XCTAssertNil(model.loadingTask)
 

--- a/Tests/RemoteImageTests/RemoteImageViewModelTests.swift
+++ b/Tests/RemoteImageTests/RemoteImageViewModelTests.swift
@@ -220,18 +220,8 @@ extension RemoteImageViewModel {
     XCTAssertEqual(urlSession, .shared)
     XCTAssertEqual(skipCache, false)
     XCTAssertEqual(scale, 1.0)
-    XCTAssertEqual(transaction, .init())
-    XCTAssertEqual(disableTransactionWithCachedResponse, true)
+    XCTAssertEqual(animation, .default)
+    XCTAssertEqual(disableAnimationWithCachedResponse, true)
     XCTAssertEqual(cache, .shared)
-  }
-}
-
-// MARK: - Transaction + Equatable
-
-extension Transaction: Equatable {
-  public static func ==(lhs: Transaction, rhs: Transaction) -> Bool {
-    lhs.disablesAnimations == rhs.disablesAnimations
-      && lhs.isContinuous == rhs.isContinuous
-      && lhs.animation == rhs.animation
   }
 }

--- a/Tests/RemoteImageTests/URLSessionDataTests.swift
+++ b/Tests/RemoteImageTests/URLSessionDataTests.swift
@@ -29,6 +29,6 @@ final class URLSessionDataTests: XCTestCase {
 
   // MARK: Private
 
-  private var urlSession: URLSession!
+  private var urlSession: URLSession! // swiftlint:disable:this implicitly_unwrapped_optional
 
 }

--- a/Tests/RemoteImageTests/URLSessionDataTests.swift
+++ b/Tests/RemoteImageTests/URLSessionDataTests.swift
@@ -17,13 +17,13 @@ final class URLSessionDataTests: XCTestCase {
 
   func test_dataWithCacheLoadInfo_skipCacheFalse_usesProtocolCachePolicy() async throws {
     try await urlSession.fetchImage(from: .cuteDoggoPicture)
-    let (_, _, didLoadFromCache) = try await urlSession.cachedData(from: .cuteDoggoPicture, skipCache: false)
+    let (_, _, didLoadFromCache) = try await urlSession.data(from: .cuteDoggoPicture, skipCache: false)
     XCTAssertEqual(didLoadFromCache, true)
   }
 
   func test_dataWithCacheLoadInfo_skipCacheTrue_usesReloadIgnoringLocalCacheData() async throws {
     try await urlSession.fetchImage(from: .cuteDoggoPicture)
-    let (_, _, didLoadFromCache) = try await urlSession.cachedData(from: .cuteDoggoPicture, skipCache: true)
+    let (_, _, didLoadFromCache) = try await urlSession.data(from: .cuteDoggoPicture, skipCache: true)
     XCTAssertEqual(didLoadFromCache, false)
   }
 

--- a/Tests/RemoteImageTests/URLSessionDataTests.swift
+++ b/Tests/RemoteImageTests/URLSessionDataTests.swift
@@ -15,14 +15,14 @@ final class URLSessionDataTests: XCTestCase {
     urlSession = .stubbed(responseProvider: RemoteImageStubbedURL.self)
   }
 
-  func test_dataWithCacheLoadInfo_skipCacheFalse_usesProtocolCachePolicy() async throws {
-    try await urlSession.fetchImage(from: .cuteDoggoPicture)
+  func test_dataWithCacheLoadInfo_skipCache_false() async throws {
+    _ = try await urlSession.data(from: .cuteDoggoPicture)
     let (_, _, didLoadFromCache) = try await urlSession.data(from: .cuteDoggoPicture, skipCache: false)
     XCTAssertEqual(didLoadFromCache, true)
   }
 
-  func test_dataWithCacheLoadInfo_skipCacheTrue_usesReloadIgnoringLocalCacheData() async throws {
-    try await urlSession.fetchImage(from: .cuteDoggoPicture)
+  func test_dataWithCacheLoadInfo_skipCache_true() async throws {
+    _ = try await urlSession.data(from: .cuteDoggoPicture)
     let (_, _, didLoadFromCache) = try await urlSession.data(from: .cuteDoggoPicture, skipCache: true)
     XCTAssertEqual(didLoadFromCache, false)
   }


### PR DESCRIPTION
### TL;DR

Added SwiftFormat and SwiftLint configuration, updated Swift toolchain to 5.9, and enabled strict concurrency checking.

### What changed?

- Added `.swiftformat` configuration with comprehensive formatting rules
- Added `.swiftlint.yml` with custom rules for code quality
- Updated Swift tools version from 5.8 to 5.9
- Enabled experimental `StrictConcurrency` feature for all targets
- Updated package dependencies to their latest versions
- Renamed `transaction` to `animation` in `RemoteImageConfiguration` for clarity
- Renamed `URLSession.cachedData` to `URLSession.data` for consistency
- Fixed thread-safety in `CacheListener` with `OSAllocatedUnfairLock`
- Updated demo app with improved examples and renamed "Custom content" to "Custom failure"
- Applied consistent code formatting throughout the codebase

### How to test?

1. Build and run the project to ensure it compiles with Swift 5.9
2. Run the demo app and verify all image loading examples work correctly
3. Verify that the SwiftFormat and SwiftLint configurations apply correctly by making a small change and running the formatters

### Why make this change?

This change improves code quality and maintainability by enforcing consistent formatting and linting rules. Updating to Swift 5.9 and enabling strict concurrency checking helps catch potential thread-safety issues. The renamed properties and methods provide better clarity about their purpose, while the updated dependencies ensure compatibility with the latest Swift ecosystem.