### PR TITLE
Add Swift 6 package manifest

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -1,0 +1,37 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+  name: "RemoteImage",
+  platforms: [
+    .macOS(.v13),
+    .iOS(.v16),
+  ],
+  products: [
+    .library(name: "RemoteImage", targets: ["RemoteImage"])
+  ],
+  dependencies: [
+    .package(url: "https://github.com/bdbergeron/Stubby", .upToNextMajor(from: "1.0.0")),
+    .package(url: "https://github.com/nalexn/ViewInspector", .upToNextMajor(from: "0.10.0")),
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.0"),
+  ],
+  targets: [
+    .target(
+      name: "RemoteImage",
+      dependencies: []
+    ),
+    .testTarget(
+      name: "RemoteImageTests",
+      dependencies: [
+        .target(name: "RemoteImage"),
+        .product(name: "ViewInspector", package: "ViewInspector"),
+        .product(name: "Stubby", package: "Stubby"),
+      ],
+      resources: [
+        .process("Resources")
+      ]
+    ),
+  ],
+  swiftLanguageModes: [.v6]
+)


### PR DESCRIPTION
### TL;DR

Added Swift 6 support with a dedicated Package manifest file.

### What changed?

Added a new `Package@swift-6.0.swift` file to support Swift 6 language mode. The manifest:
- Sets the Swift tools version to 6.0
- Specifies platform requirements (macOS 13+ and iOS 16+)
- Configures dependencies including Stubby, ViewInspector, and swift-docc-plugin
- Defines the RemoteImage target and its test target with appropriate dependencies
- Explicitly sets `swiftLanguageModes: [.v6]` to use Swift 6 language features

### How to test?

1. Use Swift 6 toolchain to build the package
2. Verify that the package builds successfully with Swift 6
3. Run tests to ensure compatibility with Swift 6 language mode

### Why make this change?

To ensure the RemoteImage package is compatible with Swift 6, allowing users to take advantage of the latest Swift language features while maintaining the library's functionality. This provides forward compatibility for projects that adopt Swift 6.